### PR TITLE
Update swagger-ui to latest development edition. (Fixes #15)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,6 @@
     "tests"
   ],
   "dependencies": {
-    "swagger-ui": "https://github.com/swagger-api/swagger-ui.git#f1e394b3c9061b9cf7aaa786ea5daa79360033e6"
+    "swagger-ui": "https://github.com/swagger-api/swagger-ui.git#b3dc9c004702a1f81921a9b75f86bf0a31996928"
   }
 }


### PR DESCRIPTION
By using the latest development edition of swagger-ui, it fixes successfully issue #15.