### PR TITLE
Passthrough positional arguments of RequestParser constructor (fix #47)

### DIFF
--- a/flask_restplus/reqparse.py
+++ b/flask_restplus/reqparse.py
@@ -14,5 +14,5 @@ class Argument(reqparse.Argument):
 
 
 class RequestParser(reqparse.RequestParser):
-    def __init__(self, argument_class=Argument, **kwargs):
-        super(RequestParser, self).__init__(argument_class, **kwargs)
+    def __init__(self, argument_class=Argument, *args, **kwargs):
+        super(RequestParser, self).__init__(argument_class, *args, **kwargs)

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -40,3 +40,7 @@ class ReqParseTestCase(TestCase):
 
         data = self.post('/reqparse', {'todo': {'task': 'aaa'}})
         self.assertEqual(data, {'task': 'aaa'})
+
+    def test_copy(self):
+        parser = self.parser
+        cloned = parser.copy()


### PR DESCRIPTION
This fixes #47 