### PR TITLE
Use proper 'collectionFormat' for reqparse choices

### DIFF
--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -111,6 +111,7 @@ def parser_to_params(parser):
             param['type'] = 'array'
         if arg.choices:
             param['enum'] = arg.choices
+            param['collectionFormat'] = 'multi'
         # if param['in'] == 'body':
         #     params['body'] = param
         # else:

--- a/tests/test_swagger_utils.py
+++ b/tests/test_swagger_utils.py
@@ -173,6 +173,7 @@ class ParserToParamsTestCase(unittest.TestCase):
                 'type': 'string',
                 'in': 'query',
                 'enum': ['a', 'b'],
+                'collectionFormat': 'multi',
             }
         })
 


### PR DESCRIPTION
The swagger spec allows for multiple different collection formats to be
specified. By default csv (comma delimited) is used but this does not
work well with reqparses way of working which is multi in the swagger
spec (foo=bar&foo=baz).