### PR TITLE
Fix incorrect example

### DIFF
--- a/doc/documenting.rst
+++ b/doc/documenting.rst
@@ -712,7 +712,7 @@ You can apply this requirement globally with the security constructor parameter:
             'keyname': HEADER_API_KEY
         }
     }
-    api = Api(app, authorizations=authorizations, security='security')
+    api = Api(app, authorizations=authorizations, security='apikey')
 
 
 You can have multiple security schemes:


### PR DESCRIPTION
I could be wrong about this example being incorrect but judging from the other parts of the documentation about the security stuff this seems right.