### PR TITLE
Fix maximum recursion error (fixes #80)

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -396,6 +396,19 @@ class Api(restful.Api):
     def as_postman(self, urlvars=False, swagger=False):
         return PostmanCollectionV1(self, swagger=swagger).as_dict(urlvars=urlvars)
 
+    def validate_payload(self, func):
+        '''Perform a payload validation on expected model'''
+        def wrapper(*args, **kwargs):
+            if hasattr(func, '__apidoc__'):
+                model = func.__apidoc__.get('body')
+                validate = func.__apidoc__.get('validate', False)
+                if model and validate and hasattr(model, 'validate'):
+                    # TODO: proper content negotiation
+                    data = request.get_json()
+                    model.validate(data, self.refresolver)
+            return func(*args, **kwargs)
+        return wrapper
+
     @property
     def payload(self):
         return request.get_json()

--- a/flask_restplus/resource.py
+++ b/flask_restplus/resource.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from flask import request
-
 from flask.ext import restful
 
 
@@ -10,18 +8,8 @@ class Resource(restful.Resource):
 
     def __init__(self, api, *args, **kwargs):
         self.api = api
-        if self.validate_payload not in self.method_decorators:
-            self.method_decorators.insert(0, self.validate_payload)
+        self._add_validate_payload()
 
-    def validate_payload(self, func):
-        '''Perform a payload validation on expected model'''
-        def wrapper(*args, **kwargs):
-            if hasattr(func, '__apidoc__'):
-                model = func.__apidoc__.get('body')
-                validate = func.__apidoc__.get('validate', False)
-                if model and validate and hasattr(model, 'validate'):
-                    # TODO: proper content negociation
-                    data = request.get_json()
-                    model.validate(data, self.api.refresolver)
-            return func(*args, **kwargs)
-        return wrapper
+    def _add_validate_payload(self):
+        if self.api.validate_payload not in self.method_decorators:
+            self.method_decorators.insert(0, self.api.validate_payload)


### PR DESCRIPTION
In 0da4f64b2, JSON validation was introduced. In order to acheive this a
validate_payload() decorator was getting added to every Resource(). The
problem was because Resource() was getting instantiated new every time
it would just continue to add this method over and over until eventually
Python would die due to a maximum recursion error.

By moving the validate_payload() method to the Api() class it resolves
the issue of a new version of the method being added to each Resource().
In order to keep the ability of being able to easily change/override the
validate_payload() method a _add_validate_payload() method was added to
the Resource() init method where an end user can easily manipulate the
workflow in any subclasses.