### PR TITLE
Fixes #22: Exception is raised when init_app() is called more than once

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -200,7 +200,7 @@ class Api(restful.Api):
                 app_or_blueprint,
                 self.swagger_view(),
                 '/swagger.json',
-                endpoint='specs',
+                endpoint=str('specs'),
                 resource_class_args=(self, )
             )
 


### PR DESCRIPTION
Original issue is #22. Fix in #23 was not complete.

Once `add_resource` is called, you cannot undo it and every next run of `init_app` with another Blueprint or Flask-app will inevitably augment them with `/swagger.json` endpoint even if `add_specs=False`. Even worse, if `init_app` is called with `add_specs=True` (default) the second time, it would fail as the specs resource was already added previously.

My fix is cleaner as it mounts specs resource straight to the Blueprint/Flask-app, just like `_register_doc` does.