### PR TITLE
Add ability to pass headers from error handlers

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -29,7 +29,7 @@ from .namespace import Namespace
 from .postman import PostmanCollectionV1
 from .resource import Resource
 from .swagger import Swagger
-from .utils import merge, default_id, camel_to_dash
+from .utils import merge, default_id, camel_to_dash, unpack
 from .reqparse import RequestParser
 
 RE_RULES = re.compile('(<.*>)')
@@ -462,10 +462,10 @@ class Api(restful.Api):
         elif e.__class__ in self._error_handlers:
             handler = self._error_handlers[e.__class__]
             result = handler(e)
-            default_data, code = result if len(result) == 2 else (result, 500)
+            default_data, code, headers = unpack(result, 500)
         elif self._default_error_handler:
             result = self._default_error_handler(e)
-            default_data, code = result if len(result) == 2 else (result, 500)
+            default_data, code, headers = unpack(result, 500)
         else:
             code = 500
             default_data = {


### PR DESCRIPTION
Give user ability to pass headers from default or custom error handlers. There may be better ways to do this so I am open to suggestions. Perhaps using a more unique key like `__headers` or `__restplus_headers` as to avoid conflicting with anything. Another alternative I can think of is to make the exceptions return a third tuple value that contains the headers.