### PR TITLE
Remove unnecessary 405 code

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -504,9 +504,6 @@ class Api(restful.Api):
         elif code == 404 and current_app.config.get("ERROR_404_HELP", True):
             data['message'] = self._help_on_404(data.get('message', None))
 
-        elif code == 405:
-            headers['Allow'] = ', '.join(e.valid_methods)
-
         elif code == 406 and self.default_mediatype is None:
             # if we are handling NotAcceptable (406), make sure that
             # make_response uses a representation we support as the


### PR DESCRIPTION
After code was added to forward HTTPException headers, the code to add
the 'Allow' headers for a 405 response became unnecessary. See the
following:

https://github.com/flask-restful/flask-restful/pull/523