### PR TITLE
Add documentation for serve_challenge_on_401

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -76,6 +76,8 @@ class Api(object):
     :param bool catch_all_404s: Use :meth:`handle_error`
         to handle 404 errors throughout your app
     :param dict authorizations: A Swagger Authorizations declaration as dictionary
+    :param bool serve_challenge_on_401: Serve basic authentication challenge with 401
+        responses (default 'False')
 
     '''
 


### PR DESCRIPTION
I was trying to debug why the Swagger UI wasn't making the browser prompt for basic authentication and eventually found the `serve_challenge_on_401` option which was added with the dropping of Flask-Restful as a requirement but it doesn't show up in the generated documentation. So here's a small PR that should add it and prevent anyone else scratching their head :smile: