### PR TITLE
Use relative swagger.json URL for SwaggerUI

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -424,6 +424,15 @@ class Api(object):
         return url_for(self.endpoint('specs'), _external=True)
 
     @property
+    def specs_path(self):
+        '''
+        The Swagger specifications path
+
+        :rtype: str
+        '''
+        return url_for(self.endpoint('specs'))
+
+    @property
     def base_url(self):
         '''
         The API base absolute url

--- a/flask_restplus/apidoc.py
+++ b/flask_restplus/apidoc.py
@@ -33,4 +33,4 @@ def swagger_static(filename):
 def ui_for(api):
     '''Render a SwaggerUI for a given API'''
     return render_template('swagger-ui.html', title=api.title,
-                           specs_url=api.specs_url)
+                           specs_url=api.specs_path)


### PR DESCRIPTION
I run my flask-restplus app in the default werkzeug HTTP webserver behind a reverse HTTPS proxy.  The absolute URL of the swagger.json is problematic for the SwaggerUI AJAX call in this scenario.  All of the other resources in the HTML use relative URLs anyways.