### PR TITLE
Use OrderedDict for Models

### DIFF
--- a/flask_restplus/model.py
+++ b/flask_restplus/model.py
@@ -15,6 +15,7 @@ from .errors import abort
 from jsonschema import Draft4Validator
 from jsonschema.exceptions import ValidationError
 
+from ._compat import OrderedDict
 from .utils import not_none
 
 
@@ -27,9 +28,9 @@ def instance(cls):
     return cls
 
 
-class Model(dict, MutableMapping):
+class Model(OrderedDict, MutableMapping):
     '''
-    A thin wrapper on dict to store API doc metadata.
+    A thin wrapper on ordereddict to store API doc metadata.
 
     :param str name: The model public name
     :param str mask: an optional default model mask
@@ -189,6 +190,11 @@ class Model(dict, MutableMapping):
             path.append(name)
         key = '.'.join(str(p) for p in path)
         return key, error.message
+
+    def __deepcopy__(self, memo):
+        obj = self.__class__(self.name, [(key, copy.deepcopy(value, memo)) for key, value in self.items()], mask=self.__mask__)
+        obj.__parents__ = self.__parents__
+        return obj
 
     def __unicode__(self):
         return 'Model({name},{{{fields}}})'.format(name=self.name, fields=','.join(self.keys()))

--- a/flask_restplus/model.py
+++ b/flask_restplus/model.py
@@ -97,7 +97,7 @@ class Model(OrderedDict, MutableMapping):
 
     @cached_property
     def __schema__(self):
-        properties = {}
+        properties = OrderedDict()
         required = set()
         discriminator = None
         for name, field in iteritems(self):
@@ -158,7 +158,7 @@ class Model(OrderedDict, MutableMapping):
         :param str name: The new model name
         :param dict parents: The new model extra fields
         '''
-        fields = {}
+        fields = OrderedDict()
         for parent in parents:
             fields.update(copy.deepcopy(parent))
         return cls(name, fields)

--- a/flask_restplus/representations.py
+++ b/flask_restplus/representations.py
@@ -13,10 +13,9 @@ def output_json(data, code, headers=None):
 
     # If we're in debug mode, and the indent is not set, we set it to a
     # reasonable value here.  Note that this won't override any existing value
-    # that was set.  We also set the "sort_keys" value.
+    # that was set.
     if current_app.debug:
         settings.setdefault('indent', 4)
-        settings.setdefault('sort_keys', True)
 
     # always end the json dumps with a new line
     # see https://github.com/mitsuhiko/flask/pull/1262


### PR DESCRIPTION
Had to do some wierd stuff with `args` to get things to work with `OrderedDict`. Otherwise the `deepcopy()` in `resolved` would not work properly. Struggled finding a better way to do this but would love to hear any ideas.
