### PR TITLE
Use namespace factory for default namespace instead of code duplication

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -116,13 +116,12 @@ class Api(object):
         self.models = {}
         self._refresolver = None
         self.namespaces = []
-        self.default_namespace = Namespace(default, default_label,
+        self.default_namespace = self.namespace(default, default_label,
             endpoint='{0}-declaration'.format(default),
             validate=validate,
             api=self,
             path='/',
         )
-        self.add_namespace(self.default_namespace)
 
         self.representations = OrderedDict(DEFAULT_REPRESENTATIONS)
         self.urls = {}


### PR DESCRIPTION
Besides avoiding code duplication, it makes possible to override one method to replace `Namespace` class with user's implementation.