### PR TITLE
Closes #138: Added new OAuth-related config options for Swagger-UI

### DIFF
--- a/flask_restplus/templates/swagger-ui.html
+++ b/flask_restplus/templates/swagger-ui.html
@@ -13,13 +13,13 @@
                 supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
                 onComplete: function(swaggerApi, swaggerUi){
                     if(typeof initOAuth == "function") {
-                        /*
-                        initOAuth({
-                            clientId: "your-client-id",
-                            realm: "your-realms",
-                            appName: "your-app-name"
-                        });
-                        */
+                        {% if config.SWAGGER_UI_OAUTH_CLIENT_ID -%}
+                            initOAuth({
+                                clientId: "{{ config.SWAGGER_UI_OAUTH_CLIENT_ID }}",
+                                realm: "{{ config.SWAGGER_UI_OAUTH_REALM }}",
+                                appName: "{{ config.SWAGGER_UI_OAUTH_APP_NAME }}"
+                            });
+                        {%- endif %}
                     }
                     $('pre code').each(function(i, e) {
                         hljs.highlightBlock(e)


### PR DESCRIPTION
This PR is related to issue #138.

You neeed to specify `app.config.SWAGGER_UI_OAUTH_CLIENT_ID` to enable OAuth support in Swagger-UI.

There are also two optional (though recommended) config options:

* `SWAGGER_UI_OAUTH_REALM`
* `SWAGGER_UI_OAUTH_APP_NAME`