### PR TITLE
Fix error messages from reqparse

### DIFF
--- a/flask_restplus/reqparse.py
+++ b/flask_restplus/reqparse.py
@@ -169,8 +169,9 @@ class Argument(object):
             dict with the name of the argument and the error message to be
             bundled
         '''
+        help_str = '{0}'.format(self.help) if self.help else ''
         error_str = six.text_type(error)
-        error_msg = self.help.format(error_msg=error_str) if self.help else error_str
+        error_msg = ' '.join([help_str, error_str]) if help_str else error_str
         errors = {self.name: error_msg}
 
         if bundle_errors:
@@ -222,7 +223,7 @@ class Argument(object):
                         return self.handle_validation_error(error, bundle_errors)
 
                     if self.choices and value not in self.choices:
-                        msg = '{0} is not a valid choice'.format(value)
+                        msg = 'The value \'{0}\' is not a valid choice for \'{1}\'.'.format(value, name)
                         if bundle_errors:
                             return self.handle_validation_error(msg, bundle_errors)
                         self.handle_validation_error(msg, bundle_errors)

--- a/tests/test_reqparse.py
+++ b/tests/test_reqparse.py
@@ -39,25 +39,14 @@ class ReqParseTestCase(TestCase):
             self.assertEqual(args['todo'], {'task': 'aaa'})
 
     @patch('flask_restplus.reqparse.abort')
-    def test_help_with_error_msg(self, abort):
+    def test_help(self, abort):
         parser = RequestParser()
-        parser.add_argument('foo', choices=('one', 'two'), help='Bad choice: {error_msg}')
+        parser.add_argument('foo', choices=('one', 'two'), help='Bad choice.')
         req = Mock(['values'])
         req.values = MultiDict([('foo', 'three')])
         with self.app.app_context():
             parser.parse_args(req)
-        expected = {'foo': 'Bad choice: three is not a valid choice'}
-        abort.assert_called_with(400, 'Input payload validation failed', errors=expected)
-
-    @patch('flask_restplus.reqparse.abort')
-    def test_help_no_error_msg(self, abort):
-        parser = RequestParser()
-        parser.add_argument('foo', choices=['one', 'two'], help='Please select a valid choice')
-        req = Mock(['values'])
-        req.values = MultiDict([('foo', 'three')])
-        with self.app.app_context():
-            parser.parse_args(req)
-        expected = {'foo': 'Please select a valid choice'}
+        expected = {'foo': 'Bad choice. The value \'three\' is not a valid choice for \'foo\'.'}
         abort.assert_called_with(400, 'Input payload validation failed', errors=expected)
 
     @patch('flask_restplus.reqparse.abort', side_effect=BadRequest('Bad Request'))
@@ -69,7 +58,7 @@ class ReqParseTestCase(TestCase):
         with self.app.app_context():
             with self.assertRaises(BadRequest):
                 parser.parse_args(req)
-        expected = {'foo': 'three is not a valid choice'}
+        expected = {'foo': 'The value \'three\' is not a valid choice for \'foo\'.'}
         abort.assert_called_with(400, 'Input payload validation failed', errors=expected)
 
     def test_viewargs(self):


### PR DESCRIPTION
Before the request parser from Flask-RESTful was brought into
Flask-RESTPlus a commit was made to format the help messages of a parser
argument when creating the error string. This doesn't really work that
well with Flask-RESTPlus since those help messages are also used in the
swagger documentation. If someone wanted to retain this same
functionality another argument property would likely be needed. This
reverts things to how they worked previous to the merger.
