### PR TITLE
Updated API to make it work under an HTTPS load balancer.

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -417,11 +417,11 @@ class Api(object):
     @property
     def specs_url(self):
         '''
-        The Swagger specifications absolute url (ie. `swagger.json`)
+        The Swagger specifications relative url (ie. `swagger.json`)
 
         :rtype: str
         '''
-        return url_for(self.endpoint('specs'), _external=True)
+        return url_for(self.endpoint('specs'), _external=False)
 
     @property
     def base_url(self):


### PR DESCRIPTION
The previous solution hardcoded the absolute url in the HTML file, which caused problems, when a web service is served behind HTTPS proxy.
