### PR TITLE
model definitions should report their type

### DIFF
--- a/flask_restplus/model.py
+++ b/flask_restplus/model.py
@@ -112,6 +112,7 @@ class Model(dict, MutableMapping):
             'properties': properties,
             'discriminator': discriminator,
             'x-mask': str(self.__mask__) if self.__mask__ else None,
+            'type': 'object',
         })
 
         if self.__parents__:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -26,7 +26,8 @@ class ModelTestCase(TestCase):
                     'type': 'string',
                     'format': 'date-time'
                 }
-            }
+            },
+            'type': 'object'
         })
 
     def test_model_as_nested_dict(self):
@@ -57,7 +58,8 @@ class ModelTestCase(TestCase):
                 'address': {
                     '$ref': '#/definitions/Address',
                 }
-            }
+            },
+            'type': 'object'
         })
 
         self.assertEqual(address.__schema__, {
@@ -65,7 +67,8 @@ class ModelTestCase(TestCase):
                 'road': {
                     'type': 'string'
                 },
-            }
+            },
+            'type': 'object'
         })
 
     def test_model_as_dict_with_list(self):
@@ -89,7 +92,8 @@ class ModelTestCase(TestCase):
                         'type': 'string'
                     }
                 }
-            }
+            },
+            'type': 'object'
         })
 
     def test_model_as_nested_dict_with_list(self):
@@ -123,7 +127,8 @@ class ModelTestCase(TestCase):
                         '$ref': '#/definitions/Address',
                     }
                 }
-            }
+            },
+            'type': 'object'
         })
 
         self.assertEqual(address.__schema__, {
@@ -131,7 +136,8 @@ class ModelTestCase(TestCase):
                 'road': {
                     'type': 'string'
                 },
-            }
+            },
+            'type': 'object'
         })
 
     def test_model_with_required(self):
@@ -154,7 +160,8 @@ class ModelTestCase(TestCase):
                     'format': 'date-time'
                 }
             },
-            'required': ['birthdate', 'name']
+            'required': ['birthdate', 'name'],
+            'type': 'object'
         })
 
     def test_model_as_nested_dict_and_required(self):
@@ -185,7 +192,8 @@ class ModelTestCase(TestCase):
                 'address': {
                     '$ref': '#/definitions/Address',
                 }
-            }
+            },
+            'type': 'object'
         })
 
         self.assertEqual(address.__schema__, {
@@ -193,7 +201,8 @@ class ModelTestCase(TestCase):
                 'road': {
                     'type': 'string'
                 },
-            }
+            },
+            'type': 'object'
         })
 
     def test_model_with_discriminator(self):
@@ -208,7 +217,8 @@ class ModelTestCase(TestCase):
                 'age': {'type': 'integer'},
             },
             'discriminator': 'name',
-            'required': ['name']
+            'required': ['name'],
+            'type': 'object'
         })
 
     def test_model_with_discriminator_override_require(self):
@@ -223,7 +233,8 @@ class ModelTestCase(TestCase):
                 'age': {'type': 'integer'},
             },
             'discriminator': 'name',
-            'required': ['name']
+            'required': ['name'],
+            'type': 'object'
         })
 
     def test_clone_from_instance(self):
@@ -252,7 +263,8 @@ class ModelTestCase(TestCase):
                 'extra': {
                     'type': 'string'
                 }
-            }
+            },
+            'type': 'object'
         })
 
     def test_clone_from_class(self):
@@ -281,7 +293,8 @@ class ModelTestCase(TestCase):
                 'extra': {
                     'type': 'string'
                 }
-            }
+            },
+            'type': 'object'
         })
 
     def test_clone_from_instance_with_multiple_parents(self):
@@ -317,7 +330,8 @@ class ModelTestCase(TestCase):
                 'extra': {
                     'type': 'string'
                 }
-            }
+            },
+            'type': 'object'
         })
 
     def test_clone_from_class_with_multiple_parents(self):
@@ -353,7 +367,8 @@ class ModelTestCase(TestCase):
                 'extra': {
                     'type': 'string'
                 }
-            }
+            },
+            'type': 'object'
         })
 
     def test_inherit_from_instance(self):
@@ -370,7 +385,8 @@ class ModelTestCase(TestCase):
             'properties': {
                 'name': {'type': 'string'},
                 'age': {'type': 'integer'},
-            }
+            },
+            'type': 'object'
         })
         self.assertEqual(child.__schema__, {
             'allOf': [
@@ -378,7 +394,8 @@ class ModelTestCase(TestCase):
                 {
                     'properties': {
                         'extra': {'type': 'string'}
-                    }
+                    },
+                    'type': 'object'
                 }
             ]
         })
@@ -397,7 +414,8 @@ class ModelTestCase(TestCase):
             'properties': {
                 'name': {'type': 'string'},
                 'age': {'type': 'integer'},
-            }
+            },
+            'type': 'object'
         })
         self.assertEqual(child.__schema__, {
             'allOf': [
@@ -405,7 +423,8 @@ class ModelTestCase(TestCase):
                 {
                     'properties': {
                         'extra': {'type': 'string'}
-                    }
+                    },
+                    'type': 'object'
                 }
             ]
         })
@@ -431,7 +450,8 @@ class ModelTestCase(TestCase):
                 {
                     'properties': {
                         'extra': {'type': 'string'}
-                    }
+                    },
+                    'type': 'object'
                 }
             ]
         })
@@ -457,7 +477,8 @@ class ModelTestCase(TestCase):
                 {
                     'properties': {
                         'extra': {'type': 'string'}
-                    }
+                    },
+                    'type': 'object'
                 }
             ]
         })
@@ -513,7 +534,8 @@ class ModelTestCase(TestCase):
         self.assertEqual(output.__schema__, {
             'properties': {
                 'child': {'$ref': '#/definitions/Person'},
-            }
+            },
+            'type': 'object'
         })
 
 
@@ -545,5 +567,6 @@ class ModelDeprecattionsTest(TestCase):
                 'extra': {
                     'type': 'string'
                 }
-            }
+            },
+            'type': 'object'
         })

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -1372,7 +1372,8 @@ class SwaggerTests(ApiMixin, TestCase):
                 'road': {
                     'type': 'string'
                 },
-            }
+            },
+            'type': 'object'
         })
 
         path = data['paths']['/model-as-dict/']
@@ -1500,7 +1501,8 @@ class SwaggerTests(ApiMixin, TestCase):
                     'type': 'string',
                     'format': 'date-time'
                 }
-            }
+            },
+            'type': 'object'
         })
 
         path = data['paths']['/model-as-dict/']
@@ -1599,7 +1601,8 @@ class SwaggerTests(ApiMixin, TestCase):
                         'type': 'string'
                     }
                 }
-            }
+            },
+            'type': 'object'
         })
 
         path = data['paths']['/model-with-list/']
@@ -1765,7 +1768,8 @@ class SwaggerTests(ApiMixin, TestCase):
                 'age': {'type': 'integer'},
             },
             'discriminator': 'name',
-            'required': ['name']
+            'required': ['name'],
+            'type': 'object'
         })
 
     def test_model_with_discriminator_override_require(self):
@@ -1792,7 +1796,8 @@ class SwaggerTests(ApiMixin, TestCase):
                 'age': {'type': 'integer'},
             },
             'discriminator': 'name',
-            'required': ['name']
+            'required': ['name'],
+            'type': 'object'
         })
 
     def test_model_not_found(self):
@@ -1874,7 +1879,8 @@ class SwaggerTests(ApiMixin, TestCase):
             'properties': {
                 'name': {'type': 'string'},
                 'age': {'type': 'integer'},
-            }
+            },
+            'type': 'object'
         })
         self.assertEqual(data['definitions']['Child'], {
             'allOf': [{
@@ -1882,7 +1888,8 @@ class SwaggerTests(ApiMixin, TestCase):
             }, {
                 'properties': {
                     'extra': {'type': 'string'}
-                }
+                },
+                'type': 'object'
             }]
         })
 
@@ -2100,7 +2107,8 @@ class SwaggerTests(ApiMixin, TestCase):
                     'type': 'string',
                     'format': 'date-time'
                 }
-            }
+            },
+            'type': 'object'
         })
 
         op = data['paths']['/model-as-dict/']['post']
@@ -2149,7 +2157,8 @@ class SwaggerTests(ApiMixin, TestCase):
                     'type': 'string',
                     'format': 'date-time'
                 }
-            }
+            },
+            'type': 'object'
         })
 
         op = data['paths']['/model-as-dict/']['post']
@@ -2199,7 +2208,8 @@ class SwaggerTests(ApiMixin, TestCase):
                     'type': 'string',
                     'format': 'date-time'
                 }
-            }
+            },
+            'type': 'object'
         })
 
         op = data['paths']['/model-list/']['post']
@@ -2248,7 +2258,8 @@ class SwaggerTests(ApiMixin, TestCase):
                     'type': 'string',
                     'format': 'date-time'
                 }
-            }
+            },
+            'type': 'object'
         })
 
         self.assertIn('/with-parser/', data['paths'])
@@ -2328,7 +2339,8 @@ class SwaggerTests(ApiMixin, TestCase):
                     'type': 'string',
                     'format': 'date-time'
                 }
-            }
+            },
+            'type': 'object'
         })
 
         op = data['paths']['/model-list/']['post']
@@ -2375,7 +2387,8 @@ class SwaggerTests(ApiMixin, TestCase):
                     'type': 'string',
                     'format': 'date-time'
                 }
-            }
+            },
+            'type': 'object'
         })
 
         op = data['paths']['/model-as-dict/']['post']


### PR DESCRIPTION
Definitions not having types makes it so that clients such as bravado can't figure out how to unmarshall a response. This should fix that.

I'm not certain that it's required by the standard, but every example I could find contained it and we know that at least one client expects it.