### PR TITLE
updated and integrated api and swagger for tags on paths and vendor tags

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -65,6 +65,7 @@ class Api(object):
     :param str contact: A contact email for the API (used in Swagger documentation)
     :param str license: The license associated to the API (used in Swagger documentation)
     :param str license_url: The license page URL (used in Swagger documentation)
+    :param str host: The host that the api is running on.  Not always the localhost, thought it is the default.
     :param str endpoint: The API base endpoint (default to 'api).
     :param str default: The default namespace base name (default to 'default')
     :param str default_label: The default namespace label (used in Swagger documentation)
@@ -82,7 +83,7 @@ class Api(object):
     '''
 
     def __init__(self, app=None, version='1.0', title=None, description=None,
-            terms_url=None, license=None, license_url=None,
+            terms_url=None, license=None, license_url=None, host=None,
             contact=None, contact_url=None, contact_email=None,
             authorizations=None, security=None, doc='/', default_id=default_id,
             default='default', default_label='Default namespace', validate=None,
@@ -99,6 +100,7 @@ class Api(object):
         self.contact_url = contact_url
         self.license = license
         self.license_url = license_url
+        self.host=host
         self.authorizations = authorizations
         self.security = security
         self.default_id = default_id
@@ -156,7 +158,7 @@ class Api(object):
         :param str contact: A contact email for the API (used in Swagger documentation)
         :param str license: The license associated to the API (used in Swagger documentation)
         :param str license_url: The license page URL (used in Swagger documentation)
-
+        :param str host: The host that the api is running on.  Not always the localhost, thought it is the default.
         '''
         self.title = kwargs.get('title', self.title)
         self.description = kwargs.get('description', self.description)
@@ -166,6 +168,7 @@ class Api(object):
         self.contact_email = kwargs.get('contact_email', self.contact_email)
         self.license = kwargs.get('license', self.license)
         self.license_url = kwargs.get('license_url', self.license_url)
+        self.host = kwargs.get('host', self.host)
         self._add_specs = kwargs.get('add_specs', True)
 
         # If app is a blueprint, defer the initialization

--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -178,7 +178,7 @@ class Swagger(object):
             'tags': tags,
             'definitions': self.serialize_definitions() or None,
             'responses': responses or None,
-            'host': self.get_host(),
+            'host': self.api.host or self.get_host(),
         }
         return not_none(specs)
 
@@ -305,6 +305,7 @@ class Swagger(object):
                 continue
             path[method] = self.serialize_operation(doc, method)
             path[method]['tags'] = [ns.name]
+            path[method]['tags'].extend(doc[method].get('tags', []))
         return not_none(path)
 
     def serialize_operation(self, doc, method):
@@ -325,8 +326,18 @@ class Swagger(object):
                 operation['consumes'] = ['multipart/form-data']
             else:
                 operation['consumes'] = ['application/x-www-form-urlencoded', 'multipart/form-data']
+        operation.update(self.vendor_fields(doc, method))       
         return not_none(operation)
-
+    
+    def vendor_fields(self, doc, method):
+        '''Extract custom 3rd party Vendor fields prefixed with x-
+           https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#specification-extensions
+        '''
+        exts = {}
+        for key, value in doc[method].iteritems():
+            if key.startswith('x_'):
+                exts.update({key.replace('x_', 'x-'): value})
+        return exts
     def description_for(self, doc, method):
         '''Extract the description metadata and fallback on the whole docstring'''
         parts = []


### PR DESCRIPTION
Hi!

I just got approval.  

**3 changes that I made was to allow for**

1. custom tags to be added at the path level
2. 3rd party vendor fields
3. having an explicit hostname added to the document (Example is if the doc or swagger ui should be communicating with a host and not running the service local to the doc)

This is personally my first attempt at a pull request, so please, be gentle.

Regards,
Kelvin