### PR TITLE
Calling init_app on blueprint fixed

### DIFF
--- a/doc/scaling.rst
+++ b/doc/scaling.rst
@@ -148,7 +148,6 @@ in you application:
     from apis import blueprint as api
 
     app = Flask(__name__)
-    api.init_app(app)
     app.register_blueprint(api, url_prefix='/api/1')
     app.run(debug=True)
 


### PR DESCRIPTION
I guess it made no sense to call init_app on a blueprint here