### PR TITLE
Add semantic validation for input payload

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -15,7 +15,7 @@ from flask import make_response as original_flask_make_response
 from flask.helpers import _endpoint_from_view_func
 from flask.signals import got_request_exception
 
-from jsonschema import RefResolver
+from jsonschema import RefResolver, FormatChecker
 
 from werkzeug import cached_property
 from werkzeug.datastructures import Headers
@@ -78,7 +78,9 @@ class Api(object):
     :param dict authorizations: A Swagger Authorizations declaration as dictionary
     :param bool serve_challenge_on_401: Serve basic authentication challenge with 401
         responses (default 'False')
-
+    :param FormatChecker format_checker: A jsonschema.FormatChecker object that is hooked into
+    the Model validator. A default or a custom FormatChecker can be provided (e.g., with custom
+    checkers), otherwise the default action is to not enforce any format validation.
     '''
 
     def __init__(self, app=None, version='1.0', title=None, description=None,
@@ -88,7 +90,7 @@ class Api(object):
             default='default', default_label='Default namespace', validate=None,
             tags=None, prefix='',
             default_mediatype='application/json', decorators=None,
-            catch_all_404s=False, serve_challenge_on_401=False,
+            catch_all_404s=False, serve_challenge_on_401=False, format_checker=None,
             **kwargs):
         self.version = version
         self.title = title or 'API'
@@ -115,6 +117,7 @@ class Api(object):
         self._schema = None
         self.models = {}
         self._refresolver = None
+        self.format_checker = format_checker
         self.namespaces = []
         self.default_namespace = self.namespace(default, default_label,
             endpoint='{0}-declaration'.format(default),

--- a/flask_restplus/model.py
+++ b/flask_restplus/model.py
@@ -175,8 +175,8 @@ class Model(dict, MutableMapping):
         model.__parents__ = parents[:-1]
         return model
 
-    def validate(self, data, resolver=None):
-        validator = Draft4Validator(self.__schema__, resolver=resolver)
+    def validate(self, data, resolver=None, format_checker=None):
+        validator = Draft4Validator(self.__schema__, resolver=resolver, format_checker=format_checker)
         try:
             validator.validate(data)
         except ValidationError:

--- a/flask_restplus/resource.py
+++ b/flask_restplus/resource.py
@@ -69,4 +69,4 @@ class Resource(MethodView):
                     if isinstance(expect, Model):
                         # TODO: proper content negotiation
                         data = request.get_json()
-                        expect.validate(data, self.api.refresolver)
+                        expect.validate(data, self.api.refresolver, self.api.format_checker)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -538,6 +538,26 @@ class ModelTestCase(TestCase):
             'type': 'object'
         })
 
+    def test_validate(self):
+        from jsonschema import FormatChecker
+        from werkzeug.exceptions import BadRequest
+
+        class IPAddress(fields.Raw):
+            __schema_type__ = 'string'
+            __schema_format__ = 'ipv4'
+
+        data = {'ip': '192.168.1'}
+        model = Model('MyModel', {'ip': IPAddress()})
+
+        # Test that validate without a FormatChecker does not check if a
+        # primitive type conforms to the defined format property
+        self.assertIsNone(model.validate(data))
+
+        # Test that validate with a FormatChecker enforces the check of the
+        # format property and throws an error if invalid
+        with self.assertRaises(BadRequest):
+            model.validate(data, format_checker=FormatChecker())
+
 
 class ModelDeprecattionsTest(TestCase):
     def test_extend_is_deprecated(self):


### PR DESCRIPTION
The JSON Schema specification defines the optionally-supported 'format' keyword for semantic validation of string values. [[1]](http://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-7)

For example, given the following JSON schema:
```json
{
  "type": "object",
  "properties": {
    "name": {"type": "string", "format": "ipv4"}
  }
}
```
A JSON schema validator that does not conform to the 'format' keyword would render the JSON object `{"ip": "awesome-ip"}` valid, whereas one that conforms to it, would render it invalid.

Currently Flask-RESTPlus does not support the ability to add a semantic validator. With this patch, the Api constructor may receive a `jsonschema.FormatChecker` object as argument, that will be passed from the `resource.Resource.validate_payload` method to the `model.Model.validate` method, and will be used in the invocation of the `Draft4Validator` that actually performs the validation.

Resolves issue #176.