### PR TITLE
Re-work kmalyar-tic's swagger vendor tags work with python 2to3 updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,4 @@ after_success:
   - coveralls --rcfile=coverage.rc
 matrix:
   allow_failures:
-    - python: 3.3
-    - python: 3.4
-    - python: 3.5
     - python: pypy3

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,7 @@ after_success:
   - coveralls --rcfile=coverage.rc
 matrix:
   allow_failures:
+    - python: 3.3
+    - python: 3.4
+    - python: 3.5
     - python: pypy3

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+
 
 import difflib
 import inspect
@@ -32,6 +32,7 @@ from .resource import Resource
 from .swagger import Swagger
 from .utils import default_id, camel_to_dash, unpack
 from .representations import output_json
+import collections
 
 RE_RULES = re.compile('(<.*>)')
 
@@ -397,10 +398,10 @@ class Api(object):
         for resource, urls, kwargs in ns.resources:
             self.register_resource(ns, resource, *urls, **kwargs)
         # Register models
-        for name, definition in ns.models.items():
+        for name, definition in list(ns.models.items()):
             self.models[name] = definition
         # Register error handlers
-        for exception, handler in ns.error_handlers.items():
+        for exception, handler in list(ns.error_handlers.items()):
             self.error_handlers[exception] = handler
 
     def namespace(self, *args, **kwargs):
@@ -605,7 +606,7 @@ class Api(object):
     def _help_on_404(self, message=None):
         rules = dict([(RE_RULES.sub('', rule.rule), rule.rule)
                       for rule in current_app.url_map.iter_rules()])
-        close_matches = difflib.get_close_matches(request.path, rules.keys())
+        close_matches = difflib.get_close_matches(request.path, list(rules.keys()))
         if close_matches:
             # If we already have a message, add punctuation and continue it.
             message = ''.join((
@@ -655,7 +656,7 @@ class Api(object):
         :param **options: See BlueprintSetupState.add_url_rule
         '''
 
-        if callable(rule):
+        if isinstance(rule, collections.Callable):
             rule = rule(blueprint_setup.url_prefix)
         elif blueprint_setup.url_prefix:
             rule = blueprint_setup.url_prefix + rule
@@ -733,7 +734,7 @@ class Api(object):
 
         if self.serve_challenge_on_401:
             realm = current_app.config.get("HTTP_BASIC_AUTH_REALM", "flask-restplus")
-            challenge = u"{0} realm=\"{1}\"".format("Basic", realm)
+            challenge = "{0} realm=\"{1}\"".format("Basic", realm)
 
             response.headers['WWW-Authenticate'] = challenge
         return response

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -65,6 +65,7 @@ class Api(object):
     :param str contact: A contact email for the API (used in Swagger documentation)
     :param str license: The license associated to the API (used in Swagger documentation)
     :param str license_url: The license page URL (used in Swagger documentation)
+    :param str host: The host that the api is running on.  Not always the localhost, thought it is the default.
     :param str endpoint: The API base endpoint (default to 'api).
     :param str default: The default namespace base name (default to 'default')
     :param str default_label: The default namespace label (used in Swagger documentation)
@@ -84,7 +85,7 @@ class Api(object):
     '''
 
     def __init__(self, app=None, version='1.0', title=None, description=None,
-            terms_url=None, license=None, license_url=None,
+            terms_url=None, license=None, license_url=None, host=None,
             contact=None, contact_url=None, contact_email=None,
             authorizations=None, security=None, doc='/', default_id=default_id,
             default='default', default_label='Default namespace', validate=None,
@@ -101,6 +102,7 @@ class Api(object):
         self.contact_url = contact_url
         self.license = license
         self.license_url = license_url
+        self.host=host
         self.authorizations = authorizations
         self.security = security
         self.default_id = default_id
@@ -159,7 +161,7 @@ class Api(object):
         :param str contact: A contact email for the API (used in Swagger documentation)
         :param str license: The license associated to the API (used in Swagger documentation)
         :param str license_url: The license page URL (used in Swagger documentation)
-
+        :param str host: The host that the api is running on.  Not always the localhost, thought it is the default.
         '''
         self.title = kwargs.get('title', self.title)
         self.description = kwargs.get('description', self.description)
@@ -169,6 +171,7 @@ class Api(object):
         self.contact_email = kwargs.get('contact_email', self.contact_email)
         self.license = kwargs.get('license', self.license)
         self.license_url = kwargs.get('license_url', self.license_url)
+        self.host = kwargs.get('host', self.host)
         self._add_specs = kwargs.get('add_specs', True)
 
         # If app is a blueprint, defer the initialization

--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -178,7 +178,7 @@ class Swagger(object):
             'tags': tags,
             'definitions': self.serialize_definitions() or None,
             'responses': responses or None,
-            'host': self.get_host(),
+            'host': self.api.host or self.get_host(),
         }
         return not_none(specs)
 
@@ -305,6 +305,7 @@ class Swagger(object):
                 continue
             path[method] = self.serialize_operation(doc, method)
             path[method]['tags'] = [ns.name]
+            path[method]['tags'].extend(doc[method].get('tags', []))
         return not_none(path)
 
     def serialize_operation(self, doc, method):
@@ -325,8 +326,18 @@ class Swagger(object):
                 operation['consumes'] = ['multipart/form-data']
             else:
                 operation['consumes'] = ['application/x-www-form-urlencoded', 'multipart/form-data']
+        operation.update(self.vendor_fields(doc, method))       
         return not_none(operation)
-
+    
+    def vendor_fields(self, doc, method):
+        '''Extract custom 3rd party Vendor fields prefixed with x-
+           https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#specification-extensions
+        '''
+        exts = {}
+        for key, value in doc[method].iteritems():
+            if key.startswith('x_'):
+                exts.update({key.replace('x_', 'x-'): value})
+        return exts
     def description_for(self, doc, method):
         '''Extract the description metadata and fallback on the whole docstring'''
         parts = []

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -70,7 +70,8 @@ class SwaggerTests(ApiMixin, TestCase):
             contact_url='http://support.somewhere.com',
             contact_email='contact@somewhere.com',
             license='Apache 2.0',
-            license_url='http://www.apache.org/licenses/LICENSE-2.0.html'
+            license_url='http://www.apache.org/licenses/LICENSE-2.0.html',
+            host='somewhere.com'
         )
         api.init_app(self.app)
 
@@ -105,7 +106,8 @@ class SwaggerTests(ApiMixin, TestCase):
             contact_url='http://support.somewhere.com',
             contact_email='contact@somewhere.com',
             license='Apache 2.0',
-            license_url='http://www.apache.org/licenses/LICENSE-2.0.html'
+            license_url='http://www.apache.org/licenses/LICENSE-2.0.html',
+            host='somewhere.com'
         )
 
         data = self.get_specs()
@@ -139,7 +141,8 @@ class SwaggerTests(ApiMixin, TestCase):
             contact_url=lambda: 'http://support.somewhere.com',
             contact_email=lambda: 'contact@somewhere.com',
             license=lambda: 'Apache 2.0',
-            license_url=lambda: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+            license_url=lambda: 'http://www.apache.org/licenses/LICENSE-2.0.html',
+            host='somewhere.com'
         )
         api.init_app(self.app)
 

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -95,6 +95,7 @@ class SwaggerTests(ApiMixin, TestCase):
             'name': 'Apache 2.0',
             'url': 'http://www.apache.org/licenses/LICENSE-2.0.html',
         })
+        self.assertEqual(data['host'], 'somewhere.com')
 
     def test_specs_endpoint_info_delayed(self):
         api = restplus.Api(version='1.0')
@@ -131,6 +132,7 @@ class SwaggerTests(ApiMixin, TestCase):
             'name': 'Apache 2.0',
             'url': 'http://www.apache.org/licenses/LICENSE-2.0.html',
         })
+        self.assertEqual(data['host'], 'somewhere.com')
 
     def test_specs_endpoint_info_callable(self):
         api = restplus.Api(version=lambda: '1.0',
@@ -166,6 +168,7 @@ class SwaggerTests(ApiMixin, TestCase):
             'name': 'Apache 2.0',
             'url': 'http://www.apache.org/licenses/LICENSE-2.0.html',
         })
+        self.assertEqual(data['host'], 'somewhere.com')
 
     def test_specs_endpoint_no_host(self):
         restplus.Api(self.app)


### PR DESCRIPTION
A bit of an experiment to see of Travis' python 3.x passes the unit tests after merging in some 2to3 recommended changes to the impacted files. 
Unit tests do pass locally in virtualenvs for 2 & 3.