### PR TITLE
Add custom paths for ns in apis

### DIFF
--- a/doc/scaling.rst
+++ b/doc/scaling.rst
@@ -110,6 +110,31 @@ The `apis.__init__` module should aggregate them:
     api.add_namespace(nsX)
 
 
+You can define custom url-prefixes for namespaces during registering them in your API.
+You don't have to bind url-prefix while declaration of Namespace object.
+
+.. code-block:: Python
+
+    from flask_restplus import Api
+
+    from .namespace1 import api as ns1
+    from .namespace2 import api as ns2
+    # ...
+    from .namespaceX import api as nsX
+
+    api = Api(
+        title='My Title',
+        version='1.0',
+        description='A description',
+        # All API metadatas
+    )
+
+    api.add_namespace(ns1, path='/prefix/of/ns1')
+    api.add_namespace(ns2, path='/prefix/of/ns2')
+    # ...
+    api.add_namespace(nsX, path='/prefix/of/nsX')
+
+
 Using this pattern, you simple have to register your API in `app.py` like that:
 
 .. code-block:: Python

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -394,6 +394,13 @@ class Api(object):
         return [path + url for url in urls]
 
     def add_namespace(self, ns, path=None):
+        '''
+        This method registers resources from namespace for current instance of api.
+        You can use argument path for definition custom prefix url for namespace.
+        
+        :param Namespace ns: the namespace
+        :param path: registration prefix of namespace
+        '''
         if ns not in self.namespaces:
             self.namespaces.append(ns)
             if self not in ns.apis:

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -125,6 +125,7 @@ class Api(object):
             api=self,
             path='/',
         )
+        self.ns_paths = dict()
 
         self.representations = OrderedDict(DEFAULT_REPRESENTATIONS)
         self.urls = {}
@@ -385,14 +386,24 @@ class Api(object):
                 suffix += 1
         return endpoint
 
-    def add_namespace(self, ns):
+    def get_ns_path(self, ns):
+        return self.ns_paths.get(ns)
+
+    def ns_urls(self, ns, urls):
+        path = self.get_ns_path(ns) or ns.path
+        return [path + url for url in urls]
+
+    def add_namespace(self, ns, path=None):
         if ns not in self.namespaces:
             self.namespaces.append(ns)
             if self not in ns.apis:
                 ns.apis.append(self)
+            # Associate ns with prefix-path
+            if path is not None:
+                self.ns_paths[ns] = path
         # Register resources
         for resource, urls, kwargs in ns.resources:
-            self.register_resource(ns, resource, *urls, **kwargs)
+            self.register_resource(ns, resource, *self.ns_urls(ns, urls), **kwargs)
         # Register models
         for name, definition in ns.models.items():
             self.models[name] = definition

--- a/flask_restplus/namespace.py
+++ b/flask_restplus/namespace.py
@@ -30,7 +30,7 @@ class Namespace(object):
     def __init__(self, name, description=None, path=None, decorators=None, validate=None, **kwargs):
         self.name = name
         self.description = description
-        self.path = (path or ('/' + name)).rstrip('/')
+        self._path = path
 
         self._schema = None
         self._validate = validate
@@ -43,6 +43,10 @@ class Namespace(object):
         self.apis = []
         if 'api' in kwargs:
             self.apis.append(kwargs['api'])
+            
+    @property
+    def path(self):
+        return (self._path or ('/' + self.name)).rstrip('/')
 
     def add_resource(self, resource, *urls, **kwargs):
         '''
@@ -66,10 +70,10 @@ class Namespace(object):
             namespace.add_resource(Foo, '/foo', endpoint="foo")
             namespace.add_resource(FooSpecial, '/special/foo', endpoint="foo")
         '''
-        urls = [self.path + url for url in urls]
         self.resources.append((resource, urls, kwargs))
         for api in self.apis:
-            api.register_resource(self, resource, *urls, **kwargs)
+            ns_urls = api.ns_urls(self, urls)
+            api.register_resource(self, resource, *ns_urls, **kwargs)
 
     def route(self, *urls, **kwargs):
         '''

--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -163,7 +163,7 @@ class Swagger(object):
 
         for ns in self.api.namespaces:
             for resource, urls, kwargs in ns.resources:
-                for url in urls:
+                for url in self.api.ns_urls(ns, urls):
                     paths[extract_path(url)] = self.serialize_resource(ns, resource, url, kwargs)
 
         specs = {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -249,3 +249,16 @@ class APITestCase(TestCase):
         with self.context():
             self.assertEqual(url_for('api.ns_test_resource'), '/api/ns/test/')
             self.assertEqual(url_for('api.ns_test_resource_2'), '/api/ns/test2/')
+
+    def test_ns_path_prefixes(self):
+        api = restplus.Api()
+        ns = restplus.Namespace('test_ns', description='Test namespace')
+        @ns.route('/test/', endpoint='test_resource')
+        class TestResource(restplus.Resource):
+            pass
+
+        api.add_namespace(ns, '/api_test')
+        api.init_app(self.app)
+
+        with self.context():
+            self.assertEqual(url_for('test_resource'), '/api_test/test/')


### PR DESCRIPTION
Hello!

I very love your namespace objects, but it isn't flexible. I add support of bind custom prefix path in Api.add_namespace method.

Example of namespace file
```python
#mymodule.py

ns = restplus.Namespace('test_ns', description='Test namespace')

@ns.route('/test/', endpoint='test_resource')
class TestResource(restplus.Resource):
    pass
```

And create application
```python
#app.py

import mymodule

app = flask.Flask(__name__)
api = restplus.Api(app)

api.add_namespace(mymodule.ns, '/api_test')
```

In result I bind `mymodule.ns` on prefix path `'/api_test'`. If you try generate url by `url_for('test_resource')`, then you will get url `/api_test/test/`.