### PR TITLE
Fix prefix trailing slash stripping in Postman doc generation

### DIFF
--- a/flask_restplus/postman.py
+++ b/flask_restplus/postman.py
@@ -38,7 +38,7 @@ class Request(object):
 
     @property
     def url(self):
-        return self.collection.api.base_url[:-1] + self.path
+        return self.collection.api.base_url.rstrip('/') + self.path
 
     @property
     def headers(self):

--- a/tests/test_postman.py
+++ b/tests/test_postman.py
@@ -156,6 +156,40 @@ class PostmanTestCase(TestCase):
             request = list(filter(lambda r: r['id'] == request_id, data['requests']))[0]
             self.assertEqual(request['name'], expected)
 
+    def test_prefix_with_trailing_slash(self):
+        api = restplus.Api(self.app, prefix='/prefix/')
+
+        @api.route('/test/')
+        class Test(restplus.Resource):
+            @api.doc('test_post')
+            def post(self):
+                pass
+
+        data = api.as_postman()
+
+        validate(data, schema)
+
+        self.assertEqual(len(data['requests']), 1)
+        request = data['requests'][0]
+        self.assertEqual(request['url'], 'http://localhost/prefix/test/')
+
+    def test_prefix_without_trailing_slash(self):
+        api = restplus.Api(self.app, prefix='/prefix')
+
+        @api.route('/test/')
+        class Test(restplus.Resource):
+            @api.doc('test_post')
+            def post(self):
+                pass
+
+        data = api.as_postman()
+
+        validate(data, schema)
+
+        self.assertEqual(len(data['requests']), 1)
+        request = data['requests'][0]
+        self.assertEqual(request['url'], 'http://localhost/prefix/test/')
+
     def test_path_variables(self):
         api = restplus.Api(self.app)
 


### PR DESCRIPTION
Having a resource with path "/resource/", when the api has the prefix "/api", resulted in the url "/ap/resource/" in postman doc (missing "i").

This change checks the slash existence before removing it.