### PR TITLE
Fix typo in __init__.py

### DIFF
--- a/flask_restplus/__init__.py
+++ b/flask_restplus/__init__.py
@@ -23,7 +23,7 @@ __all__ = (
     'marshal_with_field',
     'Mask',
     'Model',
-    'SchemaModel'
+    'SchemaModel',
     'abort',
     'cors',
     'fields',


### PR DESCRIPTION
Missing comma between 'SchemaModel' and  'abort' was causing error:

     AttributeError: module 'flask_restplus' has no attribute 'SchemaModelabort'

when doing `from flask_restplus import *`