### PR TITLE
added vendor_fields function, extract custom 3rd party Vendor fields …

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 Current
 -------
 
-- Nothing yet
+- add vendor extension support (:issue:`97`)
 
 0.10.0 (2017-02-12)
 -------------------

--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -325,7 +325,24 @@ class Swagger(object):
                 operation['consumes'] = ['multipart/form-data']
             else:
                 operation['consumes'] = ['application/x-www-form-urlencoded', 'multipart/form-data']
+        for key, value in doc[method].items():
+            if key.startswith('x_'):
+                operation.update(self.vendor_fields(doc, method))
         return not_none(operation)
+
+    def vendor_fields(self, doc, method):
+        '''Extract custom 3rd party Vendor fields prefixed with x-
+            https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#specification-extensions
+        '''
+        exts = {}
+        for key, value in doc[method].items():
+            if key.startswith('x_'):
+                exts.update({key.replace('x_', 'x-'): value})
+        if exts.keys():
+            for v_exts in exts.keys():
+                return exts[v_exts]
+        else:
+            return exts
 
     def description_for(self, doc, method):
         '''Extract the description metadata and fallback on the whole docstring'''

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -2769,6 +2769,30 @@ class SwaggerTests(ApiMixin, TestCase):
         self.assertIn('deprecated', post_operation)
         self.assertTrue(post_operation['deprecated'])
 
+    def test_vendor_fields(self):
+        api = self.build_api()
+
+        @api.route('/vendor_fields', endpoint='vendor_fields')
+        class TestResource(restplus.Resource):
+            @api.doc(x_vendor_fields={
+                'x-some-integration': {
+                    'integration1': '1'
+                }
+            })
+            def get(self, age):
+                return {}
+
+        data = self.get_specs()
+
+        self.assertIn('/vendor_fields', data['paths'])
+
+        path = data['paths']['/vendor_fields']['get']
+        self.assertIn('x-some-integration', path)
+
+        path = path['x-some-integration']['integration1']
+        self.assertEqual(path, '1')
+
+
     def test_method_restrictions(self):
         api = self.build_api()
 


### PR DESCRIPTION
…prefixed with x-

Tested with AWS API GW.

 $ tox

    py26: commands succeeded
    py27: commands succeeded
    py33: commands succeeded
    py34: commands succeeded
    py35: commands succeeded
    py36: commands succeeded
    pypy: commands succeeded
    pypy3: commands succeeded
    doc: commands succeeded
    congratulations :)