### PR TITLE
Add support for optional type arguments in URLs e.g. string(length=2).

### DIFF
--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -68,6 +68,9 @@ def extract_path_params(path):
     params = OrderedDict()
     for match in RE_PARAMS.findall(path):
         descriptor, name = match.split(':') if ':' in match else (None, match)
+        if descriptor and '(' in descriptor:  # optional arg e.g. string(length=2)
+            descriptor = descriptor.split('(')[0]
+
         param = {
             'name': name,
             'in': 'path',
@@ -79,7 +82,7 @@ def extract_path_params(path):
         elif descriptor in current_app.url_map.converters:
             param['type'] = 'string'
         else:
-            raise ValueError('Unsupported type converter')
+            raise ValueError('Unsupported type converter: %s' % descriptor)
         params[name] = param
     return params
 

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -496,6 +496,26 @@ class SwaggerTests(ApiMixin, TestCase):
         self.assertEqual(parameter['in'], 'path')
         self.assertEqual(parameter['required'], True)
 
+    def test_path_parameter_with_type_with_argument(self):
+        api = self.build_api()
+
+        @api.route('/name/<string(length=2):id>/', endpoint='by-name')
+        class ByNameResource(restplus.Resource):
+            def get(self, id):
+                return {}
+
+        data = self.get_specs()
+        self.assertIn('/name/{id}/', data['paths'])
+
+        path = data['paths']['/name/{id}/']
+        self.assertEqual(len(path['parameters']), 1)
+
+        parameter = path['parameters'][0]
+        self.assertEqual(parameter['name'], 'id')
+        self.assertEqual(parameter['type'], 'string')
+        self.assertEqual(parameter['in'], 'path')
+        self.assertEqual(parameter['required'], True)
+
     def test_path_parameter_with_explicit_details(self):
         api = self.build_api()
 


### PR DESCRIPTION
Fixes #233 and #243.