### PR TITLE
Preserve order of parameters

### DIFF
--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -220,7 +220,7 @@ class Swagger(object):
         if doc is False:
             return False
         doc['name'] = resource.__name__
-        params = merge(self.expected_params(doc), doc.get('params', {}))
+        params = merge(self.expected_params(doc), doc.get('params', OrderedDict()))
         params = merge(params, extract_path_params(url))
         doc['params'] = params
         for method in [m.lower() for m in resource.methods or []]:
@@ -241,7 +241,7 @@ class Swagger(object):
         return doc
 
     def expected_params(self, doc):
-        params = {}
+        params = OrderedDict()
         if 'expect' not in doc:
             return params
 


### PR DESCRIPTION
It is useful for Swagger Codegen since most of the programming languages rely on the function parameters order.