### PR TITLE
[swagger] Parse docstring

### DIFF
--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -3,7 +3,9 @@ from __future__ import unicode_literals, absolute_import
 
 import itertools
 import re
+import xml.etree.ElementTree as ET
 
+from docutils.core import publish_doctree
 from inspect import isclass, getdoc
 from collections import OrderedDict, Hashable
 from six import string_types, itervalues, iteritems, iterkeys
@@ -38,8 +40,6 @@ RE_URL = re.compile(r'<(?:[^:<>]+:)?([^<>]+)>')
 
 DEFAULT_RESPONSE_DESCRIPTION = 'Success'
 DEFAULT_RESPONSE = {'description': DEFAULT_RESPONSE_DESCRIPTION}
-
-RE_RAISES = re.compile(r'^:raises\s+(?P<name>[\w\d_]+)\s*:\s*(?P<description>.*)$', re.MULTILINE)
 
 
 def ref(model):
@@ -108,20 +108,24 @@ def _clean_header(header):
 
 def parse_docstring(obj):
     raw = getdoc(obj)
-    summary = raw.strip(' \n').split('\n')[0].split('.')[0] if raw else None
+    summary = []
     raises = {}
-    details = raw.replace(summary, '').lstrip('. \n').strip(' \n') if raw else None
-    for match in RE_RAISES.finditer(raw or ''):
-        raises[match.group('name')] = match.group('description')
-        if details:
-            details = details.replace(match.group(0), '')
+
+    if raw is not None:
+        tree = ET.fromstring(publish_doctree(raw).asdom().toxml())
+        summary = tree.findall('paragraph')
+
+        for field_list in tree.findall('field_list'):
+            for field in field_list.findall('field'):
+                match = re.match('^raises\s+(.*)$', field.find('field_name').text)
+                if match:
+                    raises[match.group(1)] = field.find('field_body').find('paragraph').text
+
     parsed = {
         'raw': raw,
-        'summary': summary or None,
-        'details': details or None,
-        'returns': None,
-        'params': [],
-        'raises': raises,
+        'summary': summary[0].text if summary else None,
+        'details': '\n\n'.join([s.text for s in summary[1:]]) if len(summary) > 1 else None,
+        'raises': raises
     }
     return parsed
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ long_description = '\n'.join((
 exec(compile(open('flask_restplus/__about__.py').read(), 'flask_restplus/__about__.py', 'exec'))
 
 tests_require = ['pytest', 'pytest-sugar', 'pytest-flask', 'pytest-mock', 'pytest-faker', 'blinker', 'tzlocal', 'mock']
-install_requires = ['Flask>=0.8', 'six>=1.3.0', 'pytz', 'aniso8601>=0.82', 'jsonschema']
+install_requires = ['Flask>=0.8', 'six>=1.3.0', 'pytz', 'aniso8601>=0.82', 'jsonschema', 'docutils']
 doc_require = ['sphinx', 'alabaster', 'sphinx_issues']
 qa_require = ['pytest-cover', 'flake8']
 ci_require = ['invoke>=0.13'] + qa_require + tests_require

--- a/tests/test_swagger_utils.py
+++ b/tests/test_swagger_utils.py
@@ -122,9 +122,7 @@ class ParseDocstringTest(object):
         assert parsed['raw'] is None
         assert parsed['summary'] is None
         assert parsed['details'] is None
-        assert parsed['returns'] is None
         assert parsed['raises'] == {}
-        assert parsed['params'] == []
 
     def test_single_line(self):
         def func():
@@ -136,59 +134,73 @@ class ParseDocstringTest(object):
         assert parsed['raw'] == 'Some summary'
         assert parsed['summary'] == 'Some summary'
         assert parsed['details'] is None
-        assert parsed['returns'] is None
         assert parsed['raises'] == {}
-        assert parsed['params'] == []
 
     def test_multi_line(self):
         def func():
             '''
             Some summary
-            Some details
+            Some more summary
             '''
             pass
 
         parsed = parse_docstring(func)
 
-        assert parsed['raw'] == 'Some summary\nSome details'
-        assert parsed['summary'] == 'Some summary'
-        assert parsed['details'] == 'Some details'
-        assert parsed['returns'] is None
+        assert parsed['raw'] == 'Some summary\nSome more summary'
+        assert parsed['summary'] == 'Some summary\nSome more summary'
+        assert parsed['details'] is None
         assert parsed['raises'] == {}
-        assert parsed['params'] == []
 
-    def test_multi_line_and_dot(self):
+    def test_multi_paragraph(self):
         def func():
             '''
-            Some summary. bla bla
-            Some details
+            Some summary. Some more summary
+
+            Some details. Some more details
+
+            Even more details
             '''
             pass
 
         parsed = parse_docstring(func)
 
-        assert parsed['raw'] == 'Some summary. bla bla\nSome details'
-        assert parsed['summary'] == 'Some summary'
-        assert parsed['details'] == 'bla bla\nSome details'
-        assert parsed['returns'] is None
+        assert parsed['raw'] == 'Some summary. Some more summary\n\nSome details. Some more details\n\n' \
+            'Even more details'
+        assert parsed['summary'] == 'Some summary. Some more summary'
+        assert parsed['details'] == 'Some details. Some more details\n\nEven more details'
         assert parsed['raises'] == {}
-        assert parsed['params'] == []
 
     def test_raises(self):
         def func():
             '''
-            Some summary.
+            Some summary
+
             :raises SomeException: in case of something
             '''
             pass
 
         parsed = parse_docstring(func)
 
-        assert parsed['raw'] == 'Some summary.\n:raises SomeException: in case of something'
+        assert parsed['raw'] == 'Some summary\n\n:raises SomeException: in case of something'
         assert parsed['summary'] == 'Some summary'
         assert parsed['details'] is None
-        assert parsed['returns'] is None
-        assert parsed['params'] == []
-        assert parsed['raises'] == {
-            'SomeException': 'in case of something'
-        }
+        assert parsed['raises'] == {'SomeException': 'in case of something'}
+
+    def test_sphinx(self):
+        def func():
+            '''
+            Some summary
+
+            :param id: The ID
+            :type id: int
+            :returns: Nothing
+            :rtype: None
+            '''
+            pass
+
+        parsed = parse_docstring(func)
+
+        assert parsed['raw'] == 'Some summary\n\n:param id: The ID\n:type id: int\n:returns: Nothing\n:rtype: None'
+        assert parsed['summary'] == 'Some summary'
+        assert parsed['details'] is None
+        assert parsed['raises'] == {}


### PR DESCRIPTION
This PR addresses https://github.com/noirbizarre/flask-restplus/issues/249 which uses `docutils` to parse the docstring and extract the top level paragraphs and fields.

A few notes:

1. The `params` and `returns` keys were removed as they were never set.
2. Per the `docutils` parsing the `summary` and `details` fields are defined via top-level summary paragraphs, i.e., a blank line, rather than a newline as was previously the case.
3. I was unable to successfully test the entire repo even from the master branch using `inv test` per the instructions in the CONTRIBUTING.rst file. I was able to run, 

```
inv qa
pytest tests/test_swagger_utils.py 
```
