### PR TITLE
Add short descriptions for expected model (fix #61)

### DIFF
--- a/flask_restplus/namespace.py
+++ b/flask_restplus/namespace.py
@@ -192,6 +192,7 @@ class Namespace(object):
 
         :param ModelBase|Parse inputs: An expect model or request parser
         :param bool validate: whether to perform validation or not
+        :param str description: short model description
 
         '''
         expect = []
@@ -200,6 +201,8 @@ class Namespace(object):
             'expect': expect
         }
         for param in inputs:
+            if 'description' in kwargs and isinstance(param, Model):
+                param = (param, kwargs.get('description', ''))
             expect.append(param)
         return self.doc(**params)
 


### PR DESCRIPTION
Introduces the `description` keyword to ns.expect() making the documentation of an expected model more intuitive than providing a `tuple` of `(Model, "short description")` as input model.

The regarding issue #61 is closed yet, but wasn't solved as I expected it to be solved.