### PR TITLE
Add 'float' mapping to Swagger generator

### DIFF
--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -29,6 +29,7 @@ PATH_TYPES = {
 #: Maps Pyton primitives types to Swagger ones
 PY_TYPES = {
     int: 'integer',
+    float: 'number',
     str: 'string',
     bool: 'boolean',
     None: 'void'


### PR DESCRIPTION
Add `float` to list of native python types