### PR TITLE
Add an optional key argument, skip_none, in `marshal_with` and `marshal`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Current
 - Help message is now added to source error message instead of string interpolation (:issue:`147`)
 - Use pytest instead of nosetests
 - Upgrade to Swagger-UI 2.2.10
+- Add an optional key argument, ``skip_none``, in :func:`marshal_with` and :func:`marshal`
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/doc/marshalling.rst
+++ b/doc/marshalling.rst
@@ -406,6 +406,35 @@ You can also use the :attr:`__schema_format__`, ``__schema_type__`` and
         __schema_example__ = 'hello, world'
 
 
+Skip fields which value is None
+-------------------------------
+
+You can skip those fields which values is ``None`` instead of marshaling those fields with JSON value, null.
+This feature is useful to reduce the size of response when you have a lots of fields which value may be None,
+but which fields are ``None`` are unpredictable.
+
+Let consider the following example with an optional ``skip_none`` keyword argument be set to True.
+
+.. code-block:: python
+
+    >>> from flask_restplus import Model, fields, marshal_with
+    >>> import json
+    >>> model = Model('Model', {
+    ...     'name': fields.String,
+    ...     'address_1': fields.String,
+    ...     'address_2': fields.String
+    ... })
+    >>> @marshal_with(model, skip_none=True)
+    ... def get():
+    ...     return {'name': 'John', 'address_1': None}
+    ...
+    >>> get()
+    OrderedDict([('name', 'John')])
+
+You can see that ``address_1`` and ``address_2`` are skipped by :func:`marshal_with`.
+``address_1`` be skipped because value is ``None``.
+``address_2`` be skipped because the dictionary return by ``get()`` have no key, ``address_2``.
+
 Define model using JSON Schema
 ------------------------------
 

--- a/flask_restplus/marshalling.py
+++ b/flask_restplus/marshalling.py
@@ -55,17 +55,12 @@ def marshal(data, fields, envelope=None, skip_none=False, mask=None):
             out = OrderedDict([(envelope, out)])
         return out
 
-    items = []
-    for k, v in fields.items():
-        if isinstance(v, dict):
-            formatted_value = marshal(data, v)
-        else:
-            formatted_value = make(v).output(k, data)
+    items = ((k, marshal(data, v) if isinstance(v, dict)
+              else make(v).output(k, data))
+             for k, v in fields.items())
 
-        if skip_none and formatted_value is None:
-            continue
-
-        items.append((k, formatted_value))
+    if skip_none:
+        items = ((k, v) for k, v in items if v is not None)
 
     out = OrderedDict(items)
 

--- a/tests/test_marshalling.py
+++ b/tests/test_marshalling.py
@@ -32,6 +32,12 @@ class MarshallingTest(object):
         output = marshal(marshal_dict, model, envelope='hey')
         assert output == {'hey': {'foo': 'bar'}}
 
+    def test_marshal_with_skip_none(self):
+        model = OrderedDict([('foo', fields.Raw), ('bat', fields.Raw), ('qux', fields.Raw)])
+        marshal_dict = OrderedDict([('foo', 'bar'), ('bat', None)])
+        output = marshal(marshal_dict, model, skip_none=True)
+        assert output == {'foo': 'bar'}
+
     def test_marshal_decorator(self):
         model = OrderedDict([('foo', fields.Raw)])
 
@@ -48,6 +54,15 @@ class MarshallingTest(object):
             return OrderedDict([('foo', 'bar'), ('bat', 'baz')])
 
         assert try_me() == {'hey': {'foo': 'bar'}}
+
+    def test_marshal_decorator_with_skip_none(self):
+        model = OrderedDict([('foo', fields.Raw), ('bat', fields.Raw), ('qux', fields.Raw)])
+
+        @marshal_with(model, skip_none=True)
+        def try_me():
+            return OrderedDict([('foo', 'bar'), ('bat', None)])
+
+        assert try_me() == {'foo': 'bar'}
 
     def test_marshal_decorator_tuple(self):
         model = OrderedDict([('foo', fields.Raw)])
@@ -67,6 +82,16 @@ class MarshallingTest(object):
             return OrderedDict([('foo', 'bar'), ('bat', 'baz')]), 200, headers
 
         assert try_me() == ({'hey': {'foo': 'bar'}}, 200, {'X-test': 123})
+
+    def test_marshal_decorator_tuple_with_skip_none(self):
+        model = OrderedDict([('foo', fields.Raw), ('bat', fields.Raw), ('qux', fields.Raw)])
+
+        @marshal_with(model, skip_none=True)
+        def try_me():
+            headers = {'X-test': 123}
+            return OrderedDict([('foo', 'bar'), ('bat', None)]), 200, headers
+
+        assert try_me() == ({'foo': 'bar'}, 200, {'X-test': 123})
 
     def test_marshal_field_decorator(self):
         model = fields.Raw
@@ -101,6 +126,12 @@ class MarshallingTest(object):
         marshal_fields = OrderedDict([('foo', 'bar'), ('bat', 'baz')])
         output = marshal((marshal_fields,), model, envelope='hey')
         assert output == {'hey': [{'foo': 'bar'}]}
+
+    def test_marshal_tuple_with_skip_none(self):
+        model = OrderedDict([('foo', fields.Raw), ('bat', fields.Raw), ('qux', fields.Raw)])
+        marshal_fields = OrderedDict([('foo', 'bar'), ('bat', None)])
+        output = marshal((marshal_fields,), model, skip_none=True)
+        assert output == [{'foo': 'bar'}]
 
     def test_marshal_nested(self):
         model = OrderedDict([


### PR DESCRIPTION
You can skip those fields which values is `None` instead of marshaling those fields with JSON value, null.
This feature is useful to reduce the size of response when you have a lots of fields which value may be None, but which fields are `None` are unpredictable.