### PR TITLE
Use the function marshal() instead of the decorator @marshal_with().

### DIFF
--- a/doc/marshalling.rst
+++ b/doc/marshalling.rst
@@ -239,9 +239,9 @@ structures and render them appropriately. ::
     >>> resource_fields['shipping_address'] = fields.Nested(address_fields)
     >>> address1 = {'addr1': '123 fake street', 'city': 'New York', 'state': 'NY', 'zip': '10468'}
     >>> address2 = {'addr1': '555 nowhere', 'city': 'New York', 'state': 'NY', 'zip': '10468'}
-    >>> data = { 'name': 'bob', 'billing_address': address1, 'shipping_address': address2}
+    >>> data = {'name': 'bob', 'billing_address': address1, 'shipping_address': address2}
     >>>
-    >>> json.dumps(marshal_with(data, resource_fields))
+    >>> json.dumps(marshal(data, resource_fields))
     '{"billing_address": {"line 1": "123 fake street", "line 2": null, "state": "NY", "zip": "10468", "city": "New York"}, "name": "bob", "shipping_address": {"line 1": "555 nowhere", "line 2": null, "state": "NY", "zip": "10468", "city": "New York"}}'
 
 This example uses two :class:`~fields.Nested` fields.


### PR DESCRIPTION
    While here, remove an extra space.