### PR TITLE
Replaced all integer HTTP codes with HTTPStatus enum values

### DIFF
--- a/flask_restplus/_http.py
+++ b/flask_restplus/_http.py
@@ -1,0 +1,141 @@
+# encoding: utf-8
+"""
+This file is backported from Python 3.5 http built-in module.
+"""
+
+from enum import IntEnum
+
+
+class HTTPStatus(IntEnum):
+    """HTTP status codes and reason phrases
+
+    Status codes from the following RFCs are all observed:
+
+        * RFC 7231: Hypertext Transfer Protocol (HTTP/1.1), obsoletes 2616
+        * RFC 6585: Additional HTTP Status Codes
+        * RFC 3229: Delta encoding in HTTP
+        * RFC 4918: HTTP Extensions for WebDAV, obsoletes 2518
+        * RFC 5842: Binding Extensions to WebDAV
+        * RFC 7238: Permanent Redirect
+        * RFC 2295: Transparent Content Negotiation in HTTP
+        * RFC 2774: An HTTP Extension Framework
+    """
+    def __new__(cls, value, phrase, description=''):
+        obj = int.__new__(cls, value)
+        obj._value_ = value
+
+        obj.phrase = phrase
+        obj.description = description
+        return obj
+
+    def __str__(self):
+        return str(self.value)
+
+    # informational
+    CONTINUE = 100, 'Continue', 'Request received, please continue'
+    SWITCHING_PROTOCOLS = (101, 'Switching Protocols',
+            'Switching to new protocol; obey Upgrade header')
+    PROCESSING = 102, 'Processing'
+
+    # success
+    OK = 200, 'OK', 'Request fulfilled, document follows'
+    CREATED = 201, 'Created', 'Document created, URL follows'
+    ACCEPTED = (202, 'Accepted',
+        'Request accepted, processing continues off-line')
+    NON_AUTHORITATIVE_INFORMATION = (203,
+        'Non-Authoritative Information', 'Request fulfilled from cache')
+    NO_CONTENT = 204, 'No Content', 'Request fulfilled, nothing follows'
+    RESET_CONTENT = 205, 'Reset Content', 'Clear input form for further input'
+    PARTIAL_CONTENT = 206, 'Partial Content', 'Partial content follows'
+    MULTI_STATUS = 207, 'Multi-Status'
+    ALREADY_REPORTED = 208, 'Already Reported'
+    IM_USED = 226, 'IM Used'
+
+    # redirection
+    MULTIPLE_CHOICES = (300, 'Multiple Choices',
+        'Object has several resources -- see URI list')
+    MOVED_PERMANENTLY = (301, 'Moved Permanently',
+        'Object moved permanently -- see URI list')
+    FOUND = 302, 'Found', 'Object moved temporarily -- see URI list'
+    SEE_OTHER = 303, 'See Other', 'Object moved -- see Method and URL list'
+    NOT_MODIFIED = (304, 'Not Modified',
+        'Document has not changed since given time')
+    USE_PROXY = (305, 'Use Proxy',
+        'You must use proxy specified in Location to access this resource')
+    TEMPORARY_REDIRECT = (307, 'Temporary Redirect',
+        'Object moved temporarily -- see URI list')
+    PERMANENT_REDIRECT = (308, 'Permanent Redirect',
+        'Object moved temporarily -- see URI list')
+
+    # client error
+    BAD_REQUEST = (400, 'Bad Request',
+        'Bad request syntax or unsupported method')
+    UNAUTHORIZED = (401, 'Unauthorized',
+        'No permission -- see authorization schemes')
+    PAYMENT_REQUIRED = (402, 'Payment Required',
+        'No payment -- see charging schemes')
+    FORBIDDEN = (403, 'Forbidden',
+        'Request forbidden -- authorization will not help')
+    NOT_FOUND = (404, 'Not Found',
+        'Nothing matches the given URI')
+    METHOD_NOT_ALLOWED = (405, 'Method Not Allowed',
+        'Specified method is invalid for this resource')
+    NOT_ACCEPTABLE = (406, 'Not Acceptable',
+        'URI not available in preferred format')
+    PROXY_AUTHENTICATION_REQUIRED = (407,
+        'Proxy Authentication Required',
+        'You must authenticate with this proxy before proceeding')
+    REQUEST_TIMEOUT = (408, 'Request Timeout',
+        'Request timed out; try again later')
+    CONFLICT = 409, 'Conflict', 'Request conflict'
+    GONE = (410, 'Gone',
+        'URI no longer exists and has been permanently removed')
+    LENGTH_REQUIRED = (411, 'Length Required',
+        'Client must specify Content-Length')
+    PRECONDITION_FAILED = (412, 'Precondition Failed',
+        'Precondition in headers is false')
+    REQUEST_ENTITY_TOO_LARGE = (413, 'Request Entity Too Large',
+        'Entity is too large')
+    REQUEST_URI_TOO_LONG = (414, 'Request-URI Too Long',
+        'URI is too long')
+    UNSUPPORTED_MEDIA_TYPE = (415, 'Unsupported Media Type',
+        'Entity body in unsupported format')
+    REQUESTED_RANGE_NOT_SATISFIABLE = (416,
+        'Requested Range Not Satisfiable',
+        'Cannot satisfy request range')
+    EXPECTATION_FAILED = (417, 'Expectation Failed',
+        'Expect condition could not be satisfied')
+    UNPROCESSABLE_ENTITY = 422, 'Unprocessable Entity'
+    LOCKED = 423, 'Locked'
+    FAILED_DEPENDENCY = 424, 'Failed Dependency'
+    UPGRADE_REQUIRED = 426, 'Upgrade Required'
+    PRECONDITION_REQUIRED = (428, 'Precondition Required',
+        'The origin server requires the request to be conditional')
+    TOO_MANY_REQUESTS = (429, 'Too Many Requests',
+        'The user has sent too many requests in '
+        'a given amount of time ("rate limiting")')
+    REQUEST_HEADER_FIELDS_TOO_LARGE = (431,
+        'Request Header Fields Too Large',
+        'The server is unwilling to process the request because its header '
+        'fields are too large')
+
+    # server errors
+    INTERNAL_SERVER_ERROR = (500, 'Internal Server Error',
+        'Server got itself in trouble')
+    NOT_IMPLEMENTED = (501, 'Not Implemented',
+        'Server does not support this operation')
+    BAD_GATEWAY = (502, 'Bad Gateway',
+        'Invalid responses from another server/proxy')
+    SERVICE_UNAVAILABLE = (503, 'Service Unavailable',
+        'The server cannot process the request due to a high load')
+    GATEWAY_TIMEOUT = (504, 'Gateway Timeout',
+        'The gateway server did not receive a timely response')
+    HTTP_VERSION_NOT_SUPPORTED = (505, 'HTTP Version Not Supported',
+        'Cannot fulfill request')
+    VARIANT_ALSO_NEGOTIATES = 506, 'Variant Also Negotiates'
+    INSUFFICIENT_STORAGE = 507, 'Insufficient Storage'
+    LOOP_DETECTED = 508, 'Loop Detected'
+    NOT_EXTENDED = 510, 'Not Extended'
+    NETWORK_AUTHENTICATION_REQUIRED = (511,
+        'Network Authentication Required',
+        'The client needs to authenticate to gain network access')

--- a/flask_restplus/errors.py
+++ b/flask_restplus/errors.py
@@ -5,6 +5,8 @@ import flask
 
 from werkzeug.exceptions import HTTPException
 
+from ._http import HTTPStatus
+
 __all__ = (
     'abort',
     'RestError',
@@ -13,7 +15,7 @@ __all__ = (
 )
 
 
-def abort(code=500, message=None, **kwargs):
+def abort(code=HTTPStatus.INTERNAL_SERVER_ERROR, message=None, **kwargs):
     '''
     Properly abort the current request.
 

--- a/flask_restplus/model.py
+++ b/flask_restplus/model.py
@@ -15,6 +15,7 @@ from jsonschema import Draft4Validator
 from jsonschema.exceptions import ValidationError
 
 from .utils import not_none
+from ._http import HTTPStatus
 
 
 RE_REQUIRED = re.compile(r'u?\'(?P<name>.*)\' is a required property', re.I | re.U)
@@ -97,7 +98,7 @@ class ModelBase(object):
         try:
             validator.validate(data)
         except ValidationError:
-            abort(400, message='Input payload validation failed',
+            abort(HTTPStatus.BAD_REQUEST, message='Input payload validation failed',
                   errors=dict(self.format_error(e) for e in validator.iter_errors(data)))
 
     def format_error(self, error):

--- a/flask_restplus/namespace.py
+++ b/flask_restplus/namespace.py
@@ -12,6 +12,7 @@ from .marshalling import marshal, marshal_with
 from .model import Model, SchemaModel
 from .reqparse import RequestParser
 from .utils import merge
+from ._http import HTTPStatus
 
 
 class Namespace(object):
@@ -212,7 +213,7 @@ class Namespace(object):
         field.__apidoc__ = merge(getattr(field, '__apidoc__', {}), {'as_list': True})
         return field
 
-    def marshal_with(self, fields, as_list=False, code=200, description=None, **kwargs):
+    def marshal_with(self, fields, as_list=False, code=HTTPStatus.OK, description=None, **kwargs):
         '''
         A decorator specifying the fields to use for serialization.
 

--- a/flask_restplus/reqparse.py
+++ b/flask_restplus/reqparse.py
@@ -14,6 +14,7 @@ from werkzeug import exceptions
 from .errors import abort, SpecsError
 from .marshalling import marshal
 from .model import Model
+from ._http import HTTPStatus
 
 
 class ParseResult(dict):
@@ -179,7 +180,7 @@ class Argument(object):
 
         if bundle_errors:
             return ValueError(error), errors
-        abort(400, 'Input payload validation failed', errors=errors)
+        abort(HTTPStatus.BAD_REQUEST, 'Input payload validation failed', errors=errors)
 
     def parse(self, request, bundle_errors=False):
         '''
@@ -360,7 +361,7 @@ class RequestParser(object):
             if found or arg.store_missing:
                 result[arg.dest or arg.name] = value
         if errors:
-            abort(400, 'Input payload validation failed', errors=errors)
+            abort(HTTPStatus.BAD_REQUEST, 'Input payload validation failed', errors=errors)
 
         if strict and req.unparsed_arguments:
             arguments = ', '.join(req.unparsed_arguments.keys())

--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -15,6 +15,7 @@ from . import fields
 from .model import Model, ModelBase
 from .reqparse import RequestParser
 from .utils import merge, not_none, not_none_sorted
+from ._http import HTTPStatus
 
 
 #: Maps Flask/Werkzeug rooting types to Swagger ones
@@ -424,7 +425,7 @@ class Swagger(object):
                         responses[code]['schema'] = self.serialize_schema(model)
                     self.process_headers(responses[code], doc, method, kwargs.get('headers'))
             if 'model' in d:
-                code = str(d.get('default_code', 200))
+                code = str(d.get('default_code', HTTPStatus.OK))
                 if code not in responses:
                     responses[code] = self.process_headers(DEFAULT_RESPONSE.copy(), doc, method)
                 responses[code]['schema'] = self.serialize_schema(d['model'])
@@ -439,7 +440,7 @@ class Swagger(object):
                             break
 
         if not responses:
-            responses['200'] = self.process_headers(DEFAULT_RESPONSE.copy(), doc, method)
+            responses[str(HTTPStatus.OK.value)] = self.process_headers(DEFAULT_RESPONSE.copy(), doc, method)
         return responses
 
     def process_headers(self, response, doc, method=None, headers=None):

--- a/flask_restplus/utils.py
+++ b/flask_restplus/utils.py
@@ -7,6 +7,8 @@ from collections import OrderedDict
 from copy import deepcopy
 from six import iteritems
 
+from ._http import HTTPStatus
+
 
 FIRST_CAP_RE = re.compile('(.)([A-Z][a-z]+)')
 ALL_CAP_RE = re.compile('([a-z0-9])([A-Z])')
@@ -78,7 +80,7 @@ def not_none_sorted(data):
     return OrderedDict((k, v) for k, v in iteritems(ordered_items) if v is not None)
 
 
-def unpack(response, default_code=200):
+def unpack(response, default_code=HTTPStatus.OK):
     '''
     Unpack a Flask standard response.
 

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ tests_require = [
     'blinker', 'tzlocal', 'mock'
 ]
 install_requires = ['Flask>=0.8', 'six>=1.3.0', 'pytz', 'aniso8601>=0.82', 'jsonschema']
+if sys.version_info < (3, 4):
+    install_requires += ['enum34']
 doc_require = ['sphinx', 'alabaster', 'sphinx_issues']
 qa_require = ['pytest-cover', 'flake8']
 ci_require = ['invoke>=0.13'] + qa_require + tests_require


### PR DESCRIPTION
This makes the code expressive and less error-prone.

P.S. It is part of my patchset from the [flask-restplus-server-example](https://github.com/frol/flask-restplus-server-example). I am going to PR marshmallow / webargs support next (#9).