### PR TITLE
Added 'produces' section support for a specific method

### DIFF
--- a/flask_restplus/namespace.py
+++ b/flask_restplus/namespace.py
@@ -288,6 +288,10 @@ class Namespace(object):
         header.update(kwargs)
         return self.doc(headers={name: header})
 
+    def produces(self, mimetypes):
+        '''A decorator to specify the MIME types the API can produce'''
+        return self.doc(produces=mimetypes)
+
     def deprecated(self, func):
         '''A decorator to mark a resource or a method as deprecated'''
         return self.doc(deprecated=True)(func)

--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -321,6 +321,9 @@ class Swagger(object):
             'parameters': self.parameters_for(doc[method]) or None,
             'security': self.security_for(doc, method),
         }
+        # Handle 'produces' mimetypes documentation
+        if 'produces' in doc[method]:
+            operation['produces'] = doc[method]['produces']
         # Handle deprecated annotation
         if doc.get('deprecated') or doc[method].get('deprecated'):
             operation['deprecated'] = True

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -2702,6 +2702,25 @@ class SwaggerTest(object):
             resp = client.open('/test/', method=method)
             assert resp.status_code == 200
 
+    def test_produces_method(self, api, client):
+        @api.route('/test/', endpoint='test')
+        class TestResource(restplus.Resource):
+            def get(self):
+                pass
+
+            @api.produces(['application/octet-stream'])
+            def post(self):
+                pass
+
+        data = client.get_specs()
+
+        get_operation = data['paths']['/test/']['get']
+        assert 'produces' not in get_operation
+
+        post_operation = data['paths']['/test/']['post']
+        assert 'produces' in post_operation
+        assert post_operation['produces'] == ['application/octet-stream']
+
     def test_deprecated_resource(self, api, client):
         @api.deprecated
         @api.route('/test/', endpoint='test')


### PR DESCRIPTION
Using `@Namespace.doc(produces=['application/octet-stream'])` decorator for a method, I can now document the mimetype of specific endpoints.