### PR TITLE
Fix str masks for marshalling is Python 2.7 (issue-217)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Current
 - Upgrade to Swagger-UI 2.2.10
 - Fix typo in comments
 - Add an optional key argument, ``skip_none``, in :func:`marshal_with` and :func:`marshal`
+- Fix masks not working correctly with Python 2.7 (:issue:`217`)
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/flask_restplus/mask.py
+++ b/flask_restplus/mask.py
@@ -34,7 +34,7 @@ class Mask(OrderedDict):
     '''
     def __init__(self, mask=None, skip=False, **kwargs):
         self.skip = skip
-        if isinstance(mask, six.text_type):
+        if isinstance(mask, six.string_types):
             super(Mask, self).__init__()
             self.parse(mask)
         elif isinstance(mask, (dict, OrderedDict)):


### PR DESCRIPTION
`six.text_type` in Python 2.7 is for unicode strings only. The fix makes it also work for standard Python 2.7 strings.