### PR TITLE
Add skip_none for fields.Nested

### DIFF
--- a/doc/marshalling.rst
+++ b/doc/marshalling.rst
@@ -435,6 +435,21 @@ You can see that ``address_1`` and ``address_2`` are skipped by :func:`marshal_w
 ``address_1`` be skipped because value is ``None``.
 ``address_2`` be skipped because the dictionary return by ``get()`` have no key, ``address_2``.
 
+Skip none in Nested fields
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If your module use :class:`fields.Nested`, you need to pass ``skip_none=True`` keyword argument to :class:`fields.Nested`.
+
+.. code-block:: python
+
+    >>> from flask_restplus import Model, fields, marshal_with
+    >>> import json
+    >>> model = Model('Model', {
+    ...     'name': fields.String,
+    ...     'location': fields.Nested(location_model, skip_none=True)
+    ... })
+
+
 Define model using JSON Schema
 ------------------------------
 

--- a/flask_restplus/fields.py
+++ b/flask_restplus/fields.py
@@ -196,10 +196,11 @@ class Nested(Raw):
     '''
     __schema_type__ = None
 
-    def __init__(self, model, allow_null=False, as_list=False, **kwargs):
+    def __init__(self, model, allow_null=False, skip_none=False, as_list=False, **kwargs):
         self.model = model
         self.as_list = as_list
         self.allow_null = allow_null
+        self.skip_none = skip_none
         super(Nested, self).__init__(**kwargs)
 
     @property
@@ -214,7 +215,7 @@ class Nested(Raw):
             elif self.default is not None:
                 return self.default
 
-        return marshal(value, self.nested)
+        return marshal(value, self.nested, skip_none=self.skip_none)
 
     def schema(self):
         schema = super(Nested, self).schema()

--- a/flask_restplus/fields.py
+++ b/flask_restplus/fields.py
@@ -189,6 +189,9 @@ class Nested(Raw):
     :param dict model: The model dictionary to nest
     :param bool allow_null: Whether to return None instead of a dictionary
         with null keys, if a nested dictionary has all-null keys
+    :param bool skip_none: Optional key will be used to eliminate inner fields
+                           which value is None or the inner field's key not
+                           exist in data
     :param kwargs: If ``default`` keyword argument is present, a nested
         dictionary will be marshaled as its value if nested dictionary is
         all-null keys (e.g. lets you return an empty JSON object instead of

--- a/flask_restplus/marshalling.py
+++ b/flask_restplus/marshalling.py
@@ -55,12 +55,12 @@ def marshal(data, fields, envelope=None, skip_none=False, mask=None):
             out = OrderedDict([(envelope, out)])
         return out
 
-    items = ((k, marshal(data, v) if isinstance(v, dict)
+    items = ((k, marshal(data, v, skip_none=skip_none) if isinstance(v, dict)
               else make(v).output(k, data))
              for k, v in fields.items())
 
     if skip_none:
-        items = ((k, v) for k, v in items if v is not None)
+        items = ((k, v) for k, v in items if v is not None and v != OrderedDict())
 
     out = OrderedDict(items)
 

--- a/tasks.py
+++ b/tasks.py
@@ -41,7 +41,7 @@ def test(ctx, profile=False):
         '--benchmark-skip',
         '--profile' if profile else None,
     )
-    lrun('py.test {0}'.format(kwargs), pty=True)
+    lrun('pytest {0}'.format(kwargs), pty=True)
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -41,7 +41,7 @@ def test(ctx, profile=False):
         '--benchmark-skip',
         '--profile' if profile else None,
     )
-    lrun('pytest {0}'.format(kwargs), pty=True)
+    lrun('py.test {0}'.format(kwargs), pty=True)
 
 
 @task

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -770,6 +770,13 @@ class NestedFieldTest(FieldTestCase):
         assert field.allow_null
         assert field.__schema__ == {'$ref': '#/definitions/NestedModel'}
 
+    def test_with_skip_none(self, api):
+        nested_fields = api.model('NestedModel', {'name': fields.String})
+        field = fields.Nested(nested_fields, skip_none=True)
+        assert not field.required
+        assert field.skip_none
+        assert field.__schema__ == {'$ref': '#/definitions/NestedModel'}
+
     def test_with_readonly(self, app):
         api = Api(app)
         nested_fields = api.model('NestedModel', {'name': fields.String})

--- a/tests/test_marshalling.py
+++ b/tests/test_marshalling.py
@@ -185,6 +185,21 @@ class MarshallingTest(object):
         expected = OrderedDict([('foo', 'bar'), ('fee', None)])
         assert output == expected
 
+    def test_marshal_nested_with_skip_none(self):
+        model = OrderedDict([
+            ('foo', fields.Raw),
+            ('fee', fields.Nested(
+                OrderedDict([
+                    ('fye', fields.String)
+                ]), skip_none=True))
+        ])
+        marshal_fields = OrderedDict([('foo', 'bar'),
+                                      ('bat', 'baz'),
+                                      ('fee', None)])
+        output = marshal(marshal_fields, model, skip_none=True)
+        expected = OrderedDict([('foo', 'bar')])
+        assert output == expected
+
     def test_allow_null_presents_data(self):
         model = OrderedDict([
             ('foo', fields.Raw),
@@ -201,6 +216,26 @@ class MarshallingTest(object):
         expected = OrderedDict([
             ('foo', 'bar'),
             ('fee', OrderedDict([('fye', None), ('blah', 'cool')]))
+        ])
+        assert output == expected
+
+    def test_skip_none_presents_data(self):
+        model = OrderedDict([
+            ('foo', fields.Raw),
+            ('fee', fields.Nested(
+                OrderedDict([
+                    ('fye', fields.String),
+                    ('blah', fields.String),
+                    ('foe', fields.String)
+                ]), skip_none=True))
+        ])
+        marshal_fields = OrderedDict([('foo', 'bar'),
+                                      ('bat', 'baz'),
+                                      ('fee', {'blah': 'cool', 'foe': None})])
+        output = marshal(marshal_fields, model)
+        expected = OrderedDict([
+            ('foo', 'bar'),
+            ('fee', OrderedDict([('blah', 'cool')]))
         ])
         assert output == expected
 
@@ -225,6 +260,32 @@ class MarshallingTest(object):
             ('foo', 'bar'),
             ('fee', OrderedDict([
                 ('fye', None),
+                ('blah', 'cool')
+            ]))
+        ])]
+        assert output == expected
+
+    def test_marshal_nested_property_with_skip_none(self):
+        class TestObject(object):
+            @property
+            def fee(self):
+                return {'blah': 'cool', 'foe': None}
+        model = OrderedDict([
+            ('foo', fields.Raw),
+            ('fee', fields.Nested(
+                OrderedDict([
+                    ('fye', fields.String),
+                    ('blah', fields.String),
+                    ('foe', fields.String)
+                ]), skip_none=True))
+        ])
+        obj = TestObject()
+        obj.foo = 'bar'
+        obj.bat = 'baz'
+        output = marshal([obj], model)
+        expected = [OrderedDict([
+            ('foo', 'bar'),
+            ('fee', OrderedDict([
                 ('blah', 'cool')
             ]))
         ])]


### PR DESCRIPTION
As @nicbou mentioned, previous PR #269 missing support `skip_none` for `fields.Nested`.
Implement the missing parts in this PR.