### PR TITLE
Adds fields checking to model constructor

### DIFF
--- a/flask_restplus/__init__.py
+++ b/flask_restplus/__init__.py
@@ -8,7 +8,7 @@ from .mask import Mask
 from .model import Model, SchemaModel  # noqa
 from .namespace import Namespace  # noqa
 from .resource import Resource  # noqa
-from .errors import abort, RestError, SpecsError, ValidationError
+from .errors import abort, RestError, SpecsError, ValidationError, ModelError
 from .swagger import Swagger
 from .__about__ import __version__, __description__
 
@@ -33,4 +33,5 @@ __all__ = (
     'SpecsError',
     'Swagger',
     'ValidationError',
+    'ModelError',
 )

--- a/flask_restplus/errors.py
+++ b/flask_restplus/errors.py
@@ -12,6 +12,7 @@ __all__ = (
     'RestError',
     'ValidationError',
     'SpecsError',
+    'ModelError',
 )
 
 
@@ -53,4 +54,9 @@ class ValidationError(RestError):
 
 class SpecsError(RestError):
     '''An helper class for incoherent specifications.'''
+    pass
+
+
+class ModelError(RestError):
+    '''An helper class for validation model.'''
     pass

--- a/flask_restplus/model.py
+++ b/flask_restplus/model.py
@@ -9,7 +9,8 @@ from collections import OrderedDict, MutableMapping
 from six import iteritems, itervalues
 
 from .mask import Mask
-from .errors import abort
+from .fields import Raw
+from .errors import abort, ModelError
 
 from jsonschema import Draft4Validator
 from jsonschema.exceptions import ValidationError
@@ -129,6 +130,16 @@ class Model(ModelBase, OrderedDict, MutableMapping):
         if self.__mask__ and not isinstance(self.__mask__, Mask):
             self.__mask__ = Mask(self.__mask__)
         super(Model, self).__init__(name, *args, **kwargs)
+
+        for fname, field in iteritems(self):
+            inst = instance(field)
+            if not isinstance(inst, Raw):
+                bases = ','.join((bs.__name__ for bs in field.__class__.__bases__))
+                field_class = '{}({})'.format(field.__class__.__name__, bases)
+                raise ModelError(
+                    'Wrong field type for model {}, {}: {}'
+                    'Field must be a child-class of fields.Raw.'
+                    ''.format(name, fname, field_class))
 
         def instance_clone(name, *parents):
             return self.__class__.clone(name, self, *parents)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import copy
 import pytest
 
-from flask_restplus import fields, Model, SchemaModel
+from flask_restplus import fields, Model, SchemaModel, ModelError
 
 
 class ModelTest(object):
@@ -698,6 +698,49 @@ class ModelDeprecattionsTest(object):
                 'extra': {
                     'type': 'string'
                 }
+            },
+            'type': 'object'
+        }
+
+
+class ModelConstraintNonFieldTest(object):
+    def test_raise_exception_if_non_field_model_attribute(self):
+        with pytest.raises(ModelError):
+            wrong = Model('Wrong', {
+                'name': fields.String,
+                'age': fields.Integer,
+                'birthdate': 'qweqwe',
+            })
+
+    def test_raise_exception_if_non_field_kwarg(self):
+        with pytest.raises(ModelError):
+            wrong = Model(
+                'Wrong',
+                {'name': fields.String},
+                age=fields.Integer,
+                birthdate='qweqwe',
+            )
+
+    def test_no_exception_when_field_in_kwarg(self):
+        correct = Model(
+            'Correct',
+            {'name': fields.String},
+            age=fields.Integer,
+            birthdate=fields.DateTime,
+        )
+
+        assert correct.__schema__ == {
+            'properties': {
+                'name': {
+                    'type': 'string'
+                },
+                'age': {
+                    'type': 'integer'
+                },
+                'birthdate': {
+                    'type': 'string',
+                    'format': 'date-time'
+                },
             },
             'type': 'object'
         }


### PR DESCRIPTION
Adds an improvement to model constructor to avoid my case of issue 194.

All test passed for 2.7 and 3.5.3 versions.
Adds few test for demonstrate how it works;

My Implementation restrict developers from creating model fields, which isn't **fields.Raw** childclass.

My issue described here: 
https://github.com/noirbizarre/flask-restplus/issues/194#issuecomment-338188199