### PR TITLE
Added static folder in web assets task

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -182,6 +182,7 @@ def assets(ctx):
     header(assets.__doc__)
     with ctx.cd(ROOT):
         ctx.run('npm install')
+        ctx.run('mkdir flask_restplus/static')
         ctx.run('cp node_modules/swagger-ui-dist/{swagger-ui*.{css,js}{,.map},favicon*.png} flask_restplus/static')
         # Until next release we need to install droid sans separately
         ctx.run('cp node_modules/typeface-droid-sans/index.css flask_restplus/static/droid-sans.css')


### PR DESCRIPTION
The folder needs to be present before assets are moved there post `npm install`, otherwise the swaggerui files return 404 for the API documentation.