### PR TITLE
Optimize calls for `resolved` property of Model

### DIFF
--- a/flask_restplus/model.py
+++ b/flask_restplus/model.py
@@ -7,6 +7,7 @@ import warnings
 
 from collections import OrderedDict, MutableMapping
 from six import iteritems, itervalues
+from werkzeug.utils import cached_property
 
 from .mask import Mask
 from .errors import abort
@@ -155,7 +156,7 @@ class Model(ModelBase, OrderedDict, MutableMapping):
             'type': 'object',
         })
 
-    @property
+    @cached_property
     def resolved(self):
         '''
         Resolve real fields before submitting them to marshal


### PR DESCRIPTION
While working on the project using flask-restplus I found a problem with poor performance of requests which marshals large lists.

I did some investigation and found it is causes by multiple deepcopies of Model. I found that all this deepcopies are from Model.resolved.

I am not sure why this `resolved` property deepcopies the model, but I tried to cache results of it and observed a huge performance gain, without visible side effect.

I've put my test code and observations here: https://gist.github.com/pax0r/bc6ebe0bdcbcc0fd16c8f76ff1c2f76e

Could someone confirm that caching this property has no obvious side-effects? Or is this deepcopy really necessary here?

If this can have some real world side effects I can write some more complicated caching mechanism for them (like checking if Model have some changes after last cached value).

The performance issue is annoying as in my project with complicated model the request with around ~500 elements may take around 3s to complete and 99% of the time is marshaling.