### PR TITLE
Provide a way to switch apidoc on and off

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -191,7 +191,9 @@ class Api(object):
         :param flask.Flask app: The flask application object
         '''
         self._register_specs(self.blueprint or app)
-        self._register_doc(self.blueprint or app)
+        apidoc_off_or_not = app.config.get('RESTPLUS_APIDOC_OFF', False)
+        if not apidoc_off_or_not:
+            self._register_doc(self.blueprint or app)
 
         app.handle_exception = partial(self.error_router, app.handle_exception)
         app.handle_user_exception = partial(self.error_router, app.handle_user_exception)
@@ -200,7 +202,8 @@ class Api(object):
             for resource, urls, kwargs in self.resources:
                 self._register_view(app, resource, *urls, **kwargs)
 
-        self._register_apidoc(app)
+        if not apidoc_off_or_not:
+            self._register_apidoc(app)
         self._validate = self._validate if self._validate is not None else app.config.get('RESTPLUS_VALIDATE', False)
         app.config.setdefault('RESTPLUS_MASK_HEADER', 'X-Fields')
         app.config.setdefault('RESTPLUS_MASK_SWAGGER', True)


### PR DESCRIPTION
Setting 'RESTPLUS_APIDOC_OFF' in app.config to be true should be able to turn of the apidoc.