### PR TITLE
API error handlers read from namespace's error handlers

### DIFF
--- a/doc/errors.rst
+++ b/doc/errors.rst
@@ -200,3 +200,16 @@ It also allows for overriding the default error handler when used without parame
     Flask-RESTPlus will return a message in the error response by default.
     If a custom response is required as an error and the message field is not needed,
     it can be disabled by setting ``ERROR_INCLUDE_MESSAGE`` to ``False`` in your application config.
+
+Error handlers can also be registered on namespaces. An error handler registered on a namespace
+will override one registered on the api.
+
+
+.. code-block:: python
+
+    ns = Namespace('cats', description='Cats related operations')
+
+    @ns.errorhandler
+    def specific_namespace_error_handler(error):
+        '''Namespace error handler'''
+        return {'message': str(error)}, getattr(error, 'code', 500)

--- a/flask_restplus/inputs.py
+++ b/flask_restplus/inputs.py
@@ -368,6 +368,8 @@ def _parse_interval(value):
             return aniso8601.parse_datetime(value), None
         except ValueError:
             return aniso8601.parse_date(value), None
+    except IndexError:
+        raise ValueError()
 
 
 def iso8601interval(value, argument='argument'):


### PR DESCRIPTION
Registration of error handlers on a namespace created using 
```
class CustomException(RuntimeError): pass

api = restplus.Api(app)
ns = api.namespace("ExceptionHandler", path="/")

@ns.errorhandler(CustomException)
def handle_custom_exception(error):
    return {'message': str(error), 'test': 'value'}, 400
```
fail to be executed because the factory `api.namespace` adds error handlers immediately to `api.error_handlers`.

I made `api.error_handlers` an internal property and on read I enhance with error handlers from child namespaces. Suggestions are welcome.

Thanks for this great package!