### PR TITLE
allow empty prefix for Namespace

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -389,11 +389,11 @@ class Api(object):
                 suffix += 1
         return endpoint
 
-    def get_ns_path(self, ns):
-        return self.ns_paths.get(ns)
+    def get_ns_path(self, ns, default=None):
+        return self.ns_paths.get(ns, default)
 
     def ns_urls(self, ns, urls):
-        path = self.get_ns_path(ns) or ns.path
+        path = self.get_ns_path(ns, ns.path)
         return [path + url for url in urls]
 
     def add_namespace(self, ns, path=None):


### PR DESCRIPTION
This allows multiple Namespace registered in the same path prefix, for example `/ns1_op` and `/ns2_op`.

```
api.add_namespace(ns1, path="")
api.add_namespace(ns2, path="")
```