### PR TITLE
Catch errors of child types

### DIFF
--- a/.eggs/README.txt
+++ b/.eggs/README.txt
@@ -1,6 +1,0 @@
-This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
-
-This directory caches those eggs to prevent repeated downloads.
-
-However, it is safe to delete this directory.
-

--- a/.eggs/README.txt
+++ b/.eggs/README.txt
@@ -1,0 +1,6 @@
+This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
+
+This directory caches those eggs to prevent repeated downloads.
+
+However, it is safe to delete this directory.
+

--- a/doc/errors.rst
+++ b/doc/errors.rst
@@ -133,10 +133,15 @@ The ``@api.errorhandler`` decorator
 -----------------------------------
 
 The :meth:`@api.errorhandler <Api.errorhandler>` decorator
-allows you to register a specific handler for a given exception, in the same manner
+allows you to register a specific handler for a given exception (or any exceptions inherited from it), in the same manner
 that you can do with Flask/Blueprint :meth:`@errorhandler <flask:flask.Flask.errorhandler>` decorator.
 
 .. code-block:: python
+
+    @api.errorhandler(RootException)
+    def handle_root_exception(error):
+        '''Return a custom message and 400 status code'''
+        return {'message': 'What you want'}, 400
 
     @api.errorhandler(CustomException)
     def handle_custom_exception(error):
@@ -181,7 +186,7 @@ In this example, the ``:raise:`` docstring will be automatically extracted
 and the response 400 will be documented properly.
 
 
-It also allows for overriding the default error handler when used wihtout parameter:
+It also allows for overriding the default error handler when used without parameter:
 
 .. code-block:: python
 

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -577,24 +577,26 @@ class Api(object):
         got_request_exception.send(current_app._get_current_object(), exception=e)
 
         headers = Headers()
-        if e.__class__ in self.error_handlers:
-            handler = self.error_handlers[e.__class__]
-            result = handler(e)
-            default_data, code, headers = unpack(result, HTTPStatus.INTERNAL_SERVER_ERROR)
-        elif isinstance(e, HTTPException):
-            code = HTTPStatus(e.code)
-            default_data = {
-                'message': getattr(e, 'description', code.phrase)
-            }
-            headers = e.get_response().headers
-        elif self._default_error_handler:
-            result = self._default_error_handler(e)
-            default_data, code, headers = unpack(result, HTTPStatus.INTERNAL_SERVER_ERROR)
+        for typecheck, handler in self.error_handlers.iteritems():
+            if isinstance(e, typecheck):
+                result = handler(e)
+                default_data, code, headers = unpack(result, HTTPStatus.INTERNAL_SERVER_ERROR)
+                break
         else:
-            code = HTTPStatus.INTERNAL_SERVER_ERROR
-            default_data = {
-                'message': code.phrase,
-            }
+            if isinstance(e, HTTPException):
+                code = HTTPStatus(e.code)
+                default_data = {
+                    'message': getattr(e, 'description', code.phrase)
+                }
+                headers = e.get_response().headers
+            elif self._default_error_handler:
+                result = self._default_error_handler(e)
+                default_data, code, headers = unpack(result, HTTPStatus.INTERNAL_SERVER_ERROR)
+            else:
+                code = HTTPStatus.INTERNAL_SERVER_ERROR
+                default_data = {
+                    'message': code.phrase,
+                }
 
         default_data['message'] = default_data.get('message', str(e))
         data = getattr(e, 'data', default_data)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -112,6 +112,31 @@ class ErrorsTest(object):
         data = json.loads(response.data.decode('utf8'))
         assert 'message' in data
 
+    def test_errorhandler_for_exception_inheritance(self, app, client):
+        api = restplus.Api(app)
+
+        class CustomException(RuntimeError):
+            pass
+
+        @api.route('/test/', endpoint='test')
+        class TestResource(restplus.Resource):
+            def get(self):
+                raise CustomException('error')
+
+        @api.errorhandler(RuntimeError)
+        def handle_custom_exception(error):
+            return {'message': str(error), 'test': 'value'}, 400
+
+        response = client.get('/test/')
+        assert response.status_code == 400
+        assert response.content_type == 'application/json'
+
+        data = json.loads(response.data.decode('utf8'))
+        assert data == {
+            'message': 'error',
+            'test': 'value',
+        }
+
     def test_errorhandler_for_custom_exception(self, app, client):
         api = restplus.Api(app)
 


### PR DESCRIPTION
Flask errorhandler catches subtypes of exceptions.

The restplus version only catches explicit errors, so if you have 50 errors all of base class MyException you need 50 api.errorhandler() decorations.

Not one api.errorhandler(MyException)