### PR TITLE
Add docs for null, Nested fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Current
 - Add an optional key argument, ``skip_none``, in :func:`marshal_with` and :func:`marshal`
 - Fix masks not working correctly with Python 2.7 (:issue:`217`)
 - Fixed typos in doc/scaling
+- Add docs for `allow_null` and :class:`~fields.Nested`
 
 Breaking changes
 ~~~~~~~~~~~~~~~~

--- a/doc/marshalling.rst
+++ b/doc/marshalling.rst
@@ -256,6 +256,8 @@ In other words:
 whereas in the previous example ``data.addr1`` was the location attribute.
 Remember: :class:`~fields.Nested` and :class:`~fields.List` objects create a new scope for attributes.
 
+By default when the sub-object is `None`, an object with default values for the nested fields will be generated instead of `null`. This can be modified by passing the `allow_null` parameter, see the :class:`~fields.Nested` constructor for more details.
+
 Use :class:`~fields.Nested` with :class:`~fields.List` to marshal lists of more complex objects:
 
 .. code-block:: python


### PR DESCRIPTION
This seems important enough to document - not allowing `null` by default was not the behavior I was expecting when using `fields.Nested`