### PR TITLE
fix basePath error when export swagger specifications

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -462,7 +462,7 @@ class Api(object):
 
         :rtype: str
         '''
-        return url_for(self.endpoint('root'))
+        return url_for(self.endpoint('root'), _external=False)
 
     @cached_property
     def __schema__(self):


### PR DESCRIPTION
When export swagger specifications. call url_for without request context, It will return basePath contains server address.

