### PR TITLE
Prevent illegal null values from creeping in

### DIFF
--- a/flask_restplus/fields.py
+++ b/flask_restplus/fields.py
@@ -109,7 +109,7 @@ class Raw(object):
     __schema_example__ = None
 
     def __init__(self, default=None, attribute=None, title=None, description=None,
-                 required=None, readonly=None, example=None, mask=None, **kwargs):
+                 required=None, readonly=None, example=None, mask=None, skip_if_null=None, **kwargs):
         self.attribute = attribute
         self.default = default
         self.title = title
@@ -118,6 +118,7 @@ class Raw(object):
         self.readonly = readonly
         self.example = example or self.__schema_example__
         self.mask = mask
+        self.skip_if_null = skip_if_null
 
     def format(self, value):
         '''
@@ -313,6 +314,7 @@ class StringMixin(object):
     __schema_type__ = 'string'
 
     def __init__(self, *args, **kwargs):
+        kwargs['skip_if_null'] = True
         self.min_length = kwargs.pop('min_length', None)
         self.max_length = kwargs.pop('max_length', None)
         self.pattern = kwargs.pop('pattern', None)

--- a/flask_restplus/fields.py
+++ b/flask_restplus/fields.py
@@ -349,6 +349,7 @@ class NumberMixin(MinMaxMixin):
     __schema_type__ = 'number'
 
     def __init__(self, *args, **kwargs):
+        kwargs['skip_if_null'] = True
         self.multiple = kwargs.pop('multiple', None)
         super(NumberMixin, self).__init__(*args, **kwargs)
 
@@ -453,6 +454,10 @@ class Boolean(Raw):
     '''
     __schema_type__ = 'boolean'
 
+    def __init__(self, **kwargs):
+        kwargs['skip_if_null'] = True
+        super(Boolean, self).__init__(**kwargs)
+
     def format(self, value):
         return bool(value)
 
@@ -471,6 +476,7 @@ class DateTime(MinMaxMixin, Raw):
     __schema_format__ = 'date-time'
 
     def __init__(self, dt_format='iso8601', **kwargs):
+        kwargs['skip_if_null'] = True
         super(DateTime, self).__init__(**kwargs)
         self.dt_format = dt_format
 

--- a/flask_restplus/marshalling.py
+++ b/flask_restplus/marshalling.py
@@ -63,6 +63,7 @@ def marshal(data, fields, envelope=None, skip_none=False, mask=None):
     if skip_none:
         items = ((k, v) for k, v in items if v is not None and v != OrderedDict())
 
+    items = ((k, v) for k, v in items if not (v is None and fields[k].skip_if_null))
     out = OrderedDict(items)
 
     if envelope:

--- a/tests/test_marshalling.py
+++ b/tests/test_marshalling.py
@@ -112,6 +112,12 @@ class MarshallingTest(object):
         output = marshal(marshal_fields, model)
         assert output == {'foo': 'bar'}
 
+    def test_marshal_skip_null_string(self):
+        model = OrderedDict({'foo': fields.String()})
+        marshal_fields = OrderedDict()
+        output = marshal(marshal_fields, model)
+        assert output == {}
+
     def test_marshal_tuple(self):
         model = OrderedDict({'foo': fields.Raw})
         marshal_fields = OrderedDict([('foo', 'bar'), ('bat', 'baz')])


### PR DESCRIPTION
**Note:** This PR needs discussion, it is a speculative attempt and not merge-ready.

I'm trying to fix a problem described [here](/noirbizarre/flask-restplus/issues/179#issuecomment-386176439), but apparently it has its own conflicts with the `allow_null` behavior for `Nested` compound items, whose use-case I don't quite understand.