### PR TITLE
use environment markers to specify enum34 requirement to fix pip install

### DIFF
--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -3,3 +3,4 @@ jsonschema
 Flask>=0.8
 pytz
 six>=1.3.0
+enum34; python_version < '3.4'

--- a/setup.py
+++ b/setup.py
@@ -59,8 +59,6 @@ long_description = '\n'.join((
 exec(compile(open('flask_restplus/__about__.py').read(), 'flask_restplus/__about__.py', 'exec'))
 
 install_requires = pip('install')
-if sys.version_info < (3, 4):
-    install_requires += ['enum34']
 doc_require = pip('doc')
 tests_require = pip('test')
 


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0508/#environment-markers

fix #443 