### PR TITLE
Todo model's id readonly property typo fix

### DIFF
--- a/examples/todomvc.py
+++ b/examples/todomvc.py
@@ -11,7 +11,7 @@ api = Api(app, version='1.0', title='TodoMVC API',
 ns = api.namespace('todos', description='TODO operations')
 
 todo = api.model('Todo', {
-    'id': fields.Integer(readOnly=True, description='The task unique identifier'),
+    'id': fields.Integer(readonly=True, description='The task unique identifier'),
     'task': fields.String(required=True, description='The task details')
 })
 


### PR DESCRIPTION
The `readonly` property had a typo, corrected that, so now the swagger UI displays the example API payload correctly (without the id field), as originally intended.