### PR TITLE
Fix late resource (route) registration

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -168,6 +168,7 @@ class Api(object):
         :param str license_url: The license page URL (used in Swagger documentation)
 
         '''
+        self.app = app
         self.title = kwargs.get('title', self.title)
         self.description = kwargs.get('description', self.description)
         self.terms_url = kwargs.get('terms_url', self.terms_url)


### PR DESCRIPTION
When `Api` is initialized without `app` and `init_app` is called before all the resources are registered, the resources end up to be 404 Not Found.

Consider the following code:

```python
api = Api(...)

app = Flask('app')
api.init_app(app)

ns = Namespace(...)
ns.route(...)

api.add_namespace(ns)
```

Without this fix, the `ns` routes end up to be not propagated to the Flask `app`, and thus the server responds with 404 Not Found.