### PR TITLE
Exception propagation in request context teardown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ doc/_build/
 # Specifics
 flask_restplus/static
 node_modules
+.idea

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -197,7 +197,7 @@ class Api(object):
         self._register_doc(self.blueprint or app)
 
         app.handle_exception = partial(self.error_router, app.handle_exception)
-        app.handle_user_exception = partial(self.error_router, app.handle_user_exception)
+        app.handle_user_exception = partial(self.user_error_router, app.handle_user_exception)
 
         if len(self.resources) > 0:
             for resource, urls, kwargs in self.resources:

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -559,14 +559,56 @@ class Api(object):
         :param function original_handler: the original Flask error handler for the app
         :param Exception e: the exception raised while handling the request
         '''
+        return self._error_router(self.handle_error, original_handler, e)
+
+    def user_error_router(self, original_handler, e):
+        '''
+        This function decides whether the error occured in a flask-restplus
+        endpoint or not. If it happened in a flask-restplus endpoint, our
+        user handler will be dispatched. If it happened in an unrelated view, the
+        app's original user error handler will be dispatched.
+        In the event that the error occurred in a flask-restplus endpoint but
+        the local handler can't resolve the situation, the router will fall
+        back onto the original_handler as last resort.
+
+        :param function original_handler: the original Flask error handler for the app
+        :param Exception e: the exception raised while handling the request
+        '''
+        return self._error_router(self.handle_user_error, original_handler, e)
+
+    def _error_router(self, handler, original_handler, e):
+        '''
+        This function decides whether the error occured in a flask-restplus
+        endpoint or not. If it happened in a flask-restplus endpoint, given handler
+        will be dispatched. If it happened in an unrelated view, the
+        given app's original error handler will be dispatched.
+        In the event that the error occurred in a flask-restplus endpoint but
+        the local handler can't resolve the situation, the router will fall
+        back onto the original_handler as last resort.
+
+        :param function handler: the error handler to dispatch on error that occured in a flask-restplus endpoint
+        :param function original_handler: the original Flask error handler for the app
+        :param Exception e: the exception raised while handling the request
+        '''
         if self._has_fr_route():
             try:
-                return self.handle_error(e)
+                return handler(e)
             except Exception:
                 pass  # Fall through to original handler
         return original_handler(e)
 
     def handle_error(self, e):
+        '''
+        Internal server Error handler for the API transforms an unknown raised exception into a Flask response,
+        with the appropriate HTTP status code and body.
+
+        :param Exception e: the raised Exception object
+
+        '''
+        code = HTTPStatus.INTERNAL_SERVER_ERROR
+        return self._make_error_response(code, {'message': code.phrase}, e, Headers())
+
+    def handle_user_error(self, e):
         '''
         Error handler for the API transforms a raised exception into a Flask response,
         with the appropriate HTTP status code and body.
@@ -575,8 +617,6 @@ class Api(object):
 
         '''
         got_request_exception.send(current_app._get_current_object(), exception=e)
-
-        include_message_in_response = current_app.config.get("ERROR_INCLUDE_MESSAGE", True)
         default_data = {}
 
         headers = Headers()
@@ -588,23 +628,33 @@ class Api(object):
         else:
             if isinstance(e, HTTPException):
                 code = HTTPStatus(e.code)
-                if include_message_in_response:
-                    default_data = {
-                        'message': getattr(e, 'description', code.phrase)
-                    }
+                default_data = {
+                    'message': getattr(e, 'description', code.phrase)
+                }
                 headers = e.get_response().headers
             elif self._default_error_handler:
                 result = self._default_error_handler(e)
                 default_data, code, headers = unpack(result, HTTPStatus.INTERNAL_SERVER_ERROR)
             else:
-                code = HTTPStatus.INTERNAL_SERVER_ERROR
-                if include_message_in_response:
-                    default_data = {
-                        'message': code.phrase,
-                    }
+                # The error looks like an unhandled one,
+                # We reraise it so the regular error_handler will handle it
+                raise e
 
+        return self._make_error_response(code, default_data, e, headers)
+
+    def _make_error_response(self, code, default_data, e, headers):
+        '''
+        Creates and returns a Flask response with given HTTP status code, body and headers based on given arguments
+        :param code: HTTP status code
+        :param default_data: Response body
+        :param e: Original exception that led to this error response
+        :param headers: Response headers
+        '''
+        include_message_in_response = current_app.config.get("ERROR_INCLUDE_MESSAGE", True)
         if include_message_in_response:
             default_data['message'] = default_data.get('message', str(e))
+        else:
+            default_data.pop('message', None)
 
         data = getattr(e, 'data', default_data)
         fallback_mediatype = None
@@ -616,7 +666,7 @@ class Api(object):
             current_app.log_exception(exc_info)
 
         elif code == HTTPStatus.NOT_FOUND and current_app.config.get("ERROR_404_HELP", True) \
-                and include_message_in_response:
+            and include_message_in_response:
             data['message'] = self._help_on_404(data.get('message', None))
 
         elif code == HTTPStatus.NOT_ACCEPTABLE and self.default_mediatype is None:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "flask-restplus",
+  "version": "0.10.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "swagger-ui-dist": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.17.5.tgz",
+      "integrity": "sha512-6iRWUpSrCmJSkcnSbf59xFd8wvszN/Tw50lMl/1CZ+yWD+DTFedKpOdJ654cn79qlEa1UXbmIW1+JC5KyI9CYA=="
+    },
+    "typeface-droid-sans": {
+      "version": "0.0.40",
+      "resolved": "https://registry.npmjs.org/typeface-droid-sans/-/typeface-droid-sans-0.0.40.tgz",
+      "integrity": "sha512-ZXfoQ5WJ+iSbF4bXo+4QlbOCOcgAZL65tfRTN095W5mUAgpbu0gRVN5JEA4W5VvPoGaxg/VUlBim84nZeeIm0Q=="
+    }
+  }
+}


### PR DESCRIPTION
When using flask extensions you often end up adding teardown function to, for example, close a db connection when the app request context is popped out.

```
def teardown(self, exception):
    ctx = stack.top
    if hasattr(ctx, 'my_connection'):
        conn = ctx.my_connection
        if isinstance(exception, MyDBConnectionTimeoutError):
            pass # Handle error
        del ctx.my_connection
```
For more information about this, please read http://flask.pocoo.org/docs/0.12/reqcontext/.

The teardown functions have a single parameter which is an optional exception allowing you to know if the context have been popped out because of the given exception or normally.
Current implementation of flask_restplus prevent from being able to retrieve this exception due to its current error handling which is pretty problematic because extensions can not perform exception based teardowns.

A possible workaround would be to register flask_restplus error handler for such exceptions and "manually" teardown extensions but this is pretty horrible as you end up calling manually extensions teardown function...

```
# line 191 api.py (flask_restplus)
app.handle_exception = partial(self.error_router, app.handle_exception)  
app.handle_user_exception = partial(self.error_router, app.handle_user_exception)
```

Previous two lines lead to our issue. When an exception is raised in your app from one of your API route, flask will trigger his own handle_exception function. The issue of this function is that it handle both user exception (ones for which you registered a handler) and unhandled exception which should actually be re-raised (as flask does by default) . Because unhandled exception are not reraised by flask_restplus, the app.handle_exception function is then never called according to following flask request handling function and the error is not stored to be passed to request context.
```
# line 1952 app.py (flask)
def wsgi_app(self, environ, start_response):
        """..."""
        ctx = self.request_context(environ)
        ctx.push()
        error = None
        try:
            try:
                # Does not raise error because flask_restplus already handled it (registered or unhandled)
                response = self.full_dispatch_request()
            except Exception as e:
                # This part is then never executed because
                error = e
                response = self.handle_exception(e)
            except:
                error = sys.exc_info()[1]
                raise
            return response(environ, start_response)
        finally:
            if self.should_ignore_error(error):
                error = None
            # Error is then None here, teardown functions will have None as exception parameter
            ctx.auto_pop(error)
```

To fix that I ended up using two "error routers", one for handled and another one for unhandled exception. The behavior follows the one from flask as the new user error handler now re-raised the error if there is no flask_restplus error handler for it. When this happens, the error is correctly bubble up to finally reach the app unhandled error handler, which, in case of a flask_restplus route, return a prettified error.

Following snippet contains the changes I did to get the presented behavior. I simply splitted up the error handling into user error handler and unhandled error handler

In _init_app function (api.py), I changed the error router for exception handling
```
app.handle_exception = partial(self.error_router, app.handle_exception)
app.handle_user_exception = partial(self.user_error_router, app.handle_user_exception)
```

Then I provided two distincts routers for user and unhandled errors
```
def error_router(self, original_handler, e):
    return self._error_router(self.handle_error, original_handler, e)

def user_error_router(self, original_handler, e):
    return self._error_router(self.handle_user_error, original_handler, e)

def _error_router(self, handler, original_handler, e):
    if self._has_fr_route():
        try:
            return handler(e)
        except Exception:
            pass  # Fall through to original handler
    return original_handler(e)
```

I finally splitted up `handler_error` function in two distincts functions, one for unhandled errors and one for user errors. I also  created a `_make_error_response` to prevent copy-pasting same code in both handlers
```
def handle_error(self, e):
    code = HTTPStatus.INTERNAL_SERVER_ERROR
    return self._make_error_response(code, {'message': code.phrase}, e, Headers())

def handle_user_error(self, e):
    got_request_exception.send(current_app._get_current_object(), exception=e)
    default_data = {}

    headers = Headers()

    for typecheck, handler in six.iteritems(self._own_and_child_error_handlers):
        if isinstance(e, typecheck):
            result = handler(e)
            default_data, code, headers = unpack(result, HTTPStatus.INTERNAL_SERVER_ERROR)
            break
    else:
        if isinstance(e, HTTPException):
            code = HTTPStatus(e.code)
            default_data = {
                'message': getattr(e, 'description', code.phrase)
            }
            headers = e.get_response().headers
        elif self._default_error_handler:
            result = self._default_error_handler(e)
            default_data, code, headers = unpack(result, HTTPStatus.INTERNAL_SERVER_ERROR)
        else:
            # The error looks like an unhandled one,
            # We reraise it so the regular error_handler will handle it
            raise e

    return self._make_error_response(code, default_data, e, headers)

def _make_error_response(self, code, default_data, e, headers):
    include_message_in_response = current_app.config.get("ERROR_INCLUDE_MESSAGE", True)
    if include_message_in_response:
        default_data['message'] = default_data.get('message', str(e))
    else:
        default_data.pop('message', None)

        data = getattr(e, 'data', default_data)
        fallback_mediatype = None

        if code >= HTTPStatus.INTERNAL_SERVER_ERROR:
            exc_info = sys.exc_info()
            if exc_info[1] is None:
                exc_info = None
            current_app.log_exception(exc_info)

        elif code == HTTPStatus.NOT_FOUND and current_app.config.get("ERROR_404_HELP", True) \
            and include_message_in_response:
            data['message'] = self._help_on_404(data.get('message', None))

        elif code == HTTPStatus.NOT_ACCEPTABLE and self.default_mediatype is None:
            # if we are handling NotAcceptable (406), make sure that
            # make_response uses a representation we support as the
            # default mediatype (so that make_response doesn't throw
            # another NotAcceptable error).
            supported_mediatypes = list(self.representations.keys())
            fallback_mediatype = supported_mediatypes[0] if supported_mediatypes else "text/plain"

        # Remove blacklisted headers
        for header in HEADERS_BLACKLIST:
            headers.pop(header, None)

        resp = self.make_response(data, code, headers, fallback_mediatype=fallback_mediatype)

        if code == HTTPStatus.UNAUTHORIZED:
            resp = self.unauthorized(resp)
        return resp
```

Feel free to include these changes in flask_restplus ;)