### PR TITLE
#513: add flag to turn Swagger-UI's 'Try it Out' on and off

### DIFF
--- a/doc/swagger.rst
+++ b/doc/swagger.rst
@@ -928,6 +928,19 @@ you can register a custom view function with the :meth:`~Api.documentation` deco
         return apidoc.ui_for(api)
 
 
+The "Try it Out" functionality in Swagger-UI can be disabled by setting ``config.SWAGGER_UI_TRY_IT_OUT`` to ``False``:
+
+.. code-block:: python
+
+    from flask import Flask
+    from flask_restplus import Api
+
+    app = Flask(__name__)
+    app.config.SWAGGER_UI_TRY_IT_OUT = False
+
+    api = Api(app)
+
+
 Disabling the documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/flask_restplus/templates/swagger-ui.html
+++ b/flask_restplus/templates/swagger-ui.html
@@ -49,6 +49,18 @@
     {% include 'swagger-ui-libs.html' %}
     <script type="text/javascript">
         window.onload = function() {
+             const DisableTryItOutPlugin = function () {
+               return {
+                 statePlugins: {
+                   spec: {
+                     wrapSelectors: {
+                       allowTryItOutFor: () => () => false
+                     }
+                   }
+                 }
+               }
+             };
+
             const ui = window.ui = new SwaggerUIBundle({
                 url: "{{ specs_url }}",
                 validatorUrl: "{{ config.SWAGGER_VALIDATOR_URL }}" || null,
@@ -58,6 +70,9 @@
                     SwaggerUIStandalonePreset.slice(1) // No Topbar
                 ],
                 plugins: [
+                    {% if config.SWAGGER_UI_TRY_IT_OUT == False -%}
+                    DisableTryItOutPlugin,
+                    {%- endif %}
                     SwaggerUIBundle.plugins.DownloadUrl
                 ],
                 displayOperationId: {{ config.SWAGGER_UI_OPERATION_ID|default(False)|tojson }},

--- a/tests/test_apidoc.py
+++ b/tests/test_apidoc.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import pytest
+import re
 
 from flask import url_for, Blueprint
 from werkzeug.routing import BuildError
@@ -62,6 +63,21 @@ class APIDocTest(object):
         app.config['SWAGGER_UI_DOC_EXPANSION'] = 'full'
         response = client.get(url_for('doc'))
         assert 'docExpansion: "full"' in str(response.data)
+
+    def test_apidoc_try_it_out_feature_flag_parameter(self, app, client):
+        restplus.Api(app)
+
+        # assert that with no config then 'Try it Out' is enabled as is default in swagger-ui
+        response = client.get(url_for('doc'))
+        assert re.compile("plugins.*?\[.*?DisableTryItOut.*?\]").match(str(response.data)) is None
+
+        app.config['SWAGGER_UI_TRY_IT_OUT'] = True
+        response = client.get(url_for('doc'))
+        assert re.compile("plugins.*?\[.*?DisableTryItOut.*?\]").match(str(response.data)) is None
+
+        app.config['SWAGGER_UI_TRY_IT_OUT'] = False
+        response = client.get(url_for('doc'))
+        assert re.compile("plugins.*?\[.*?DisableTryItOut.*?\]").search(str(response.data), re.MULTILINE)
 
     def test_apidoc_doc_display_operation_id(self, app, client):
         restplus.Api(app)


### PR DESCRIPTION
* add config.SWAGGER_UI_TRY_IT_OUT
* inject DisableTryItOut plugin in swagger-ui.html
* add check for config.SWAGGER_UI_TRY_IT_OUT in swagger-ui.html template which enables DisableTryItOut
* add tests and documentation

The default is that 'Try it Out' is enabled. If set to False then it's disabled.

First Python PR ever! Thanks for your patience :) And thanks for flask-restplus (and swagger-ui)!