### PR TITLE
Propagate exceptions from the flask-restplus handler if propagate exceptions is enabled

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -592,6 +592,13 @@ class Api(object):
         '''
         got_request_exception.send(current_app._get_current_object(), exception=e)
 
+        if not isinstance(e, HTTPException) and current_app.propagate_exceptions:
+            exc_type, exc_value, tb = sys.exc_info()
+            if exc_value is e:
+                raise
+            else:
+                raise e
+
         include_message_in_response = current_app.config.get("ERROR_INCLUDE_MESSAGE", True)
         default_data = {}
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -291,12 +291,13 @@ class ErrorsTest(object):
 
         app.config['PROPAGATE_EXCEPTIONS'] = True
 
-        response = client.get('/api/test/')
-        assert response.status_code == 500
-        assert response.content_type == 'application/json'
+        # From the Flask docs:
+        # PROPAGATE_EXCEPTIONS
+        # Exceptions are re-raised rather than being handled by the app’s error handlers.
+        # If not set, this is implicitly true if TESTING or DEBUG is enabled.
+        with pytest.raises(Exception):
+            response = client.get('/api/test/')
 
-        data = json.loads(response.data.decode('utf8'))
-        assert 'message' in data
 
     def test_custom_default_errorhandler(self, app, client):
         api = restplus.Api(app)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -296,7 +296,7 @@ class ErrorsTest(object):
         # Exceptions are re-raised rather than being handled by the app’s error handlers.
         # If not set, this is implicitly true if TESTING or DEBUG is enabled.
         with pytest.raises(Exception):
-            response = client.get('/api/test/')
+            client.get('/api/test/')
 
 
     def test_custom_default_errorhandler(self, app, client):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -298,7 +298,6 @@ class ErrorsTest(object):
         with pytest.raises(Exception):
             client.get('/api/test/')
 
-
     def test_custom_default_errorhandler(self, app, client):
         api = restplus.Api(app)
 


### PR DESCRIPTION
Propagate exceptions from the flask-restplus handler even if they come from a restplus resource (for example, if you decorate a restplus resource with Flask-JWT's @jwt_required, then restplus will catch it even if it shouldn't)