### PR TITLE
Add redirect_uri parameter for swagger

### DIFF
--- a/flask_restplus/templates/swagger-ui.html
+++ b/flask_restplus/templates/swagger-ui.html
@@ -60,6 +60,9 @@
                 plugins: [
                     SwaggerUIBundle.plugins.DownloadUrl
                 ],
+                {% if config.SWAGGER_UI_OAUTH_REDIRECT_URI -%}
+                oauth2RedirectUrl: "{{ config.SWAGGER_UI_OAUTH_REDIRECT_URI }}",
+                {%- endif %}
                 displayOperationId: {{ config.SWAGGER_UI_OPERATION_ID|default(False)|tojson }},
                 displayRequestDuration: {{ config.SWAGGER_UI_REQUEST_DURATION|default(False)|tojson }},
                 docExpansion: "{{ config.SWAGGER_UI_DOC_EXPANSION | default('none') }}"


### PR DESCRIPTION
SwaggerUIBundle allows to specify custom redirect_uri for oauth2 authentication (by default it uses "http://localhost:3200/oauth2-redirect.html"). This change allows to set this URL in config.