### PR TITLE
Update swagger.rst to fix the misspelled word 'given'

### DIFF
--- a/doc/swagger.rst
+++ b/doc/swagger.rst
@@ -547,7 +547,7 @@ You can document response headers with the ``@api.header()`` decorator shortcut.
         def get(self):
             pass
 
-If you need to specify an header that appear only on a gvien response,
+If you need to specify an header that appear only on a given response,
 just use the `@api.response` `headers` parameter.
 
 .. code-block:: python


### PR DESCRIPTION
Wanted to submit a quick PR to fix a misspelling. It's trivial, but possibly helpful.