### PR TITLE
Added the option to create namspaces using custom class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Current
 -------
 
 - Ensure `basePath` is always a path
+- Added namespace class customization to :class:`api.Api`
 
 0.12.1 (2018-09-28)
 -------------------

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -97,6 +97,7 @@ class Api(object):
             tags=None, prefix='', ordered=False,
             default_mediatype='application/json', decorators=None,
             catch_all_404s=False, serve_challenge_on_401=False, format_checker=None,
+            namespace_cls=None,
             **kwargs):
         self.version = version
         self.title = title or 'API'
@@ -126,6 +127,7 @@ class Api(object):
         self._refresolver = None
         self.format_checker = format_checker
         self.namespaces = []
+        self.namespace_cls = namespace_cls or Namespace
         self.default_namespace = self.namespace(default, default_label,
             endpoint='{0}-declaration'.format(default),
             validate=validate,
@@ -434,7 +436,8 @@ class Api(object):
         :returns Namespace: a new namespace instance
         '''
         kwargs['ordered'] = kwargs.get('ordered', self.ordered)
-        ns = Namespace(*args, **kwargs)
+        namespace_cls = kwargs.pop('namespace_cls', self.namespace_cls)
+        ns = namespace_cls(*args, **kwargs)
         self.add_namespace(ns)
         return ns
 

--- a/flask_restplus/namespace.py
+++ b/flask_restplus/namespace.py
@@ -186,7 +186,7 @@ class Namespace(object):
 
     def inherit(self, name, *specs):
         '''
-        Inherit a modal (use the Swagger composition pattern aka. allOf)
+        Inherit a model (use the Swagger composition pattern aka. allOf)
 
         .. seealso:: :meth:`Model.inherit`
         '''

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -337,3 +337,15 @@ class APITest(object):
         assert decorator1.called is True
         assert decorator2.called is True
         assert decorator3.called is True
+
+    def test_custom_namespace(self, app):
+        class MyNamespace(restplus.Namespace):
+            pass
+
+        api = restplus.Api(version='1.0', namespace_cls=MyNamespace)
+        ns = api.namespace('my_ns')
+        assert isinstance(ns, MyNamespace)
+
+        api = restplus.Api(version='1.0')
+        ns = api.namespace('my_ns', namespace_cls=MyNamespace)
+        assert isinstance(ns, MyNamespace)


### PR DESCRIPTION
In case you need to redefine something in `Namespace`'s behavior or add some custom methods (e.g. some advanced doc generator, or an all-in-one decorator for your endpoint handlers, or whatever)