### PR TITLE
Fix $ref issue of not importing Json SchemaModels

### DIFF
--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -12,7 +12,7 @@ from flask import current_app
 from werkzeug.routing import parse_rule
 
 from . import fields
-from .model import Model, ModelBase
+from .model import Model, ModelBase, SchemaModel
 from .reqparse import RequestParser
 from .utils import merge, not_none, not_none_sorted
 from ._http import HTTPStatus
@@ -511,7 +511,26 @@ class Swagger(object):
         if isinstance(specs, Model):
             for field in itervalues(specs):
                 self.register_field(field)
+        if isinstance(specs, SchemaModel):
+            self.register_Json_ref(specs._schema)
         return ref(model)
+
+    def register_Json_ref(self, jschema):
+        typeelem = jschema.get("type", "")
+        propertieselem = jschema.get("properties", "")
+        itemselem = jschema.get("items", "")
+        refelem = jschema.get("$ref", "")
+
+        if refelem != "":
+            name = refelem.split("/")[-1]
+            model = self.api.models[name]
+            self.register_model(model)
+        else:
+            if typeelem == "object" and propertieselem != "":
+                for prop_k, prop_v in propertieselem.items():
+                    self.register_Json_ref(prop_v)
+            elif typeelem == "array" and itemselem != "":
+                self.register_Json_ref(itemselem)
 
     def register_field(self, field):
         if isinstance(field, fields.Polymorph):


### PR DESCRIPTION
There are no more errors shown in Swagger Doc and the models sections in Swagger Doc show correctly the sub-schema in $ref fields. You will still need to register all models and sub-models that you expect on response or request. You register them with: api.schema_model(<NameOfModel>, <JSONSchema>)
This fix fixes the errors found in the the example found in the restplus documentation:
http://flask-restplus.readthedocs.io/en/stable/marshalling.html#define-model-using-json-schema

The fix related to the issue: JSON Schema $ref not working (not even the doc example) #275