### PR TITLE
Replace . with _ in namespace name for endpoint

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -387,7 +387,8 @@ class Api(object):
         '''
         endpoint = camel_to_dash(resource.__name__)
         if namespace is not self.default_namespace:
-            endpoint = '{ns.name}_{endpoint}'.format(ns=namespace, endpoint=endpoint)
+            ns_name = namespace.name.replace('.', '_')
+            endpoint = '{ns_name}_{endpoint}'.format(ns_name=ns_name, endpoint=endpoint)
         if endpoint in self.endpoints:
             suffix = 2
             while True:


### PR DESCRIPTION
If there is a '.' in the namespace name then this becomes part of the
endpoint name. If this endpoint is getting registered onto a blueprint
this will fail as a . is a reserved character.

We should simply replace the . with an _.

Closes: #571