### PR TITLE
Use flask app logger for exception logging

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import difflib
 import inspect
 from itertools import chain
-import logging
 import operator
 import re
 import six
@@ -42,8 +41,6 @@ RE_RULES = re.compile('(<.*>)')
 HEADERS_BLACKLIST = ('Content-Length',)
 
 DEFAULT_REPRESENTATIONS = [('application/json', output_json)]
-
-log = logging.getLogger(__name__)
 
 
 class Api(object):
@@ -485,7 +482,7 @@ class Api(object):
                 # Log the source exception for debugging purpose
                 # and return an error message
                 msg = 'Unable to render schema'
-                log.exception(msg)  # This will provide a full traceback
+                current_app.logger.exception(msg)  # Will provide full traceback
                 return {'error': msg}
         return self._schema
 

--- a/flask_restplus/mask.py
+++ b/flask_restplus/mask.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, absolute_import
 
-import logging
 import re
 import six
 
@@ -9,8 +8,6 @@ from collections import OrderedDict
 from inspect import isclass
 
 from .errors import RestError
-
-log = logging.getLogger(__name__)
 
 LEXER = re.compile(r'\{|\}|\,|[\w_:\-\*]+')
 

--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -256,10 +256,13 @@ class Swagger(object):
                 method_params = merge(method_params, method_doc.get('params', {}))
                 inherited_params = OrderedDict((k, v) for k, v in iteritems(params) if k in method_params)
                 method_doc['params'] = merge(inherited_params, method_params)
-                for name, param in method_doc['params'].items():
-                    key = (name, param.get('in', 'query'))
-                    if key in up_params:
-                        need_to_go_down.add(key)
+
+                if hasattr(method_doc['params'], 'items'):
+                    for name, param in method_doc['params'].items():
+                        key = (name, param.get('in', 'query'))
+                        if key in up_params:
+                            need_to_go_down.add(key)
+
             doc[method] = method_doc
         # Deduplicate parameters
         # For each couple (name, in), if a method overrides it,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import copy
 
 from flask import url_for, Blueprint
+import pytest
 
 import flask_restplus as restplus
 
@@ -318,6 +319,16 @@ class APITest(object):
 
         assert schema['error'] == 'Unable to render schema'
         app.logger.exception.assert_called_with('Unable to render schema')
+
+    def test_should_use_fr_error_handler_unknown_exc(self, app, mocker):
+        api = restplus.Api(app)
+        adapter = mocker.MagicMock()
+        adapter.match.side_effect = KeyError
+        mocker.patch.object(app, 'create_url_adapter', return_value=adapter)
+
+        ret = api._should_use_fr_error_handler()
+
+        assert ret is None
 
     def test_non_ordered_namespace(self, app):
         api = restplus.Api(app)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 import copy
 
 from flask import url_for, Blueprint
-import pytest
 
 import flask_restplus as restplus
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -308,6 +308,17 @@ class APITest(object):
         unified_auth.update(a2)
         assert api.__schema__["securityDefinitions"] == unified_auth
 
+    def test_api_schema_error(self, app, mocker):
+        api = restplus.Api(app)
+        mocked_swagger = mocker.patch('flask_restplus.api.Swagger', autospec=True)
+        mocked_swagger.return_value.as_dict.side_effect = Exception('boo hoo')
+        mocker.patch.object(app, 'logger', autospec=True)
+
+        schema = api.__schema__
+
+        assert schema['error'] == 'Unable to render schema'
+        app.logger.exception.assert_called_with('Unable to render schema')
+
     def test_non_ordered_namespace(self, app):
         api = restplus.Api(app)
         ns = api.namespace('ns', 'Test namespace')

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -12,6 +12,7 @@ class SchemasTest:
     def test_lazyness(self):
         schema = schemas.LazySchema('oas-2.0.json')
         assert schema._schema is None
+        assert len(schema)
 
         '' in schema  # Trigger load
         assert schema._schema is not None
@@ -39,6 +40,9 @@ class ValidationTest:
                 'swagger': '2.0',
                 'should': 'not be here',
             })
+
+        assert 'OpenAPI 2.0 validation failed' in str(excinfo)
+
         for error in excinfo.value.errors:
             assert isinstance(error, ValidationError)
 


### PR DESCRIPTION
This is a Flask extension, so it should log to the Flask app's logger, rather than defining its own logger.

In my Flask app, when `Swagger(self).as_dict()` throws an exception, I don't see the details of it in my app's log output, I guess I would need to specially configure the flask-restplus logger in order to see it, which would be unnecessarily tedious.

With this change, I see such exceptions in my app's log output, without any special setup needed.