### PR TITLE
-Fix ABC deprecations, targeted for removal in python 3.8

### DIFF
--- a/flask_restplus/reqparse.py
+++ b/flask_restplus/reqparse.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import decimal
 import six
 
-from collections import Hashable
+from collections.abc import Hashable
 from copy import deepcopy
 from flask import current_app, request
 

--- a/flask_restplus/reqparse.py
+++ b/flask_restplus/reqparse.py
@@ -4,7 +4,10 @@ from __future__ import unicode_literals
 import decimal
 import six
 
-from collections.abc import Hashable
+try:
+    from collections.abc import Hashable
+except ImportError:
+    from collections import Hashable
 from copy import deepcopy
 from flask import current_app, request
 

--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -5,7 +5,8 @@ import itertools
 import re
 
 from inspect import isclass, getdoc
-from collections import OrderedDict, Hashable
+from collections import OrderedDict
+from collections.abc import Hashable
 from six import string_types, itervalues, iteritems, iterkeys
 
 from flask import current_app

--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -6,7 +6,10 @@ import re
 
 from inspect import isclass, getdoc
 from collections import OrderedDict
-from collections.abc import Hashable
+try:
+    from collections.abc import Hashable
+except ImportError:
+    from collections import Hashable
 from six import string_types, itervalues, iteritems, iterkeys
 
 from flask import current_app


### PR DESCRIPTION
These changes avoid two warnings in python 3.7 similar to:
```
<venv>/lib/python3.7/site-packages/flask_restplus/swagger.py:8
  <venv>/lib/python3.7/site-packages/flask_restplus/swagger.py:8: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Hashable
```
Ostensibly, flask_restplus will break in python 3.8. It will fall back to old-style imports.