### PR TITLE
Suggestion: Add support for streaming

### DIFF
--- a/flask_restplus/__init__.py
+++ b/flask_restplus/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 from . import fields, reqparse, apidoc, inputs, cors
 from .api import Api  # noqa
-from .marshalling import marshal, marshal_with, marshal_with_field  # noqa
+from .marshalling import marshal, marshal_with, marshal_with_field, marshal_as_stream_with # noqa
 from .mask import Mask
 from .model import Model, OrderedModel, SchemaModel  # noqa
 from .namespace import Namespace  # noqa

--- a/tests/test_stream_marshalling.py
+++ b/tests/test_stream_marshalling.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from flask_restplus import (marshal_as_stream_with, fields, Api, Resource)
+
+
+# Add a dummy Resource to verify that the app is properly set.
+class HelloWorld(Resource):
+    def get(self):
+        return {}
+
+
+class StreamMarshallingTest(object):
+
+    def test_stream_marshalled_decorator(self, app, client):
+        api = Api(app)
+
+        class FooResource(Resource):
+
+            fields = {'foo': fields.Float}
+
+            @marshal_as_stream_with(fields)
+            def get(self):
+                def generate():
+                    yield {"foo": 3.0}
+                return generate()
+
+        api.add_resource(FooResource, '/api')
+
+        resp = client.get('/api')
+        assert resp.status_code == 200
+        assert resp.data.decode('utf-8') == '[{"foo": 3.0}]'
+
+    def test_stream_marshalled_mult(self, app, client):
+        api = Api(app)
+
+        class FooResource(Resource):
+            fields = {'foo': fields.Float}
+
+            @marshal_as_stream_with(fields)
+            def get(self):
+                def generate():
+                    for i in range(3):
+                        yield {"foo": i + 1}
+                return generate()
+
+        api.add_resource(FooResource, '/api')
+
+        resp = client.get('/api')
+        assert resp.status_code == 200
+        assert resp.data.decode('utf-8') == '[{"foo": 1.0},{"foo": 2.0},{"foo": 3.0}]'
+
+    def test_no_stream_also_marshalled(self, app, client):
+        api = Api(app)
+
+        class FooResource(Resource):
+            fields = {'foo': fields.Float}
+
+            @marshal_as_stream_with(fields)
+            def get(self):
+                return {"foo": 6.0}
+
+        api.add_resource(FooResource, '/api')
+
+        resp = client.get('/api')
+        assert resp.status_code == 200
+        assert resp.data.decode('utf-8') == '{"foo": 6.0}\n'


### PR DESCRIPTION
I have implemented support for http streaming using the flask Response object. This can be useful when generating large responses as it avoids timeouts.
In my case it has helped me to get around an annoying 30 seconds timeout on Heroku, while still being able to use the restplus object marshaling.
Additional decorators could be added if people find it useful.