### PR TITLE
added compatibility with pony ORM

### DIFF
--- a/flask_restplus/fields.py
+++ b/flask_restplus/fields.py
@@ -84,7 +84,7 @@ def to_marshallable_type(obj):
         return obj  # it is indexable it is ok
 
     if hasattr(obj, 'to_dict'):
-        return obj.to_dict() # some ORM use this method to get a mapping of the values
+        return obj.to_dict()  # some ORM use this method to get a mapping of the values
 
     return dict(obj.__dict__)
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -670,7 +670,7 @@ class UrlFieldTest(StringTestMixin, BaseFieldTestMixin, FieldTestCase):
 
         with app.test_request_context('/'):
             assert '/42' == field.output('foo', obj)
-    
+
     def test_to_dict(self, app, mocker):
         app.add_url_rule('/<foo>', 'foobar', view_func=lambda x: x)
         field = fields.Url('foobar')


### PR DESCRIPTION
Some ORMs like pony ORM use object.to_dict() instead of object.__dict__.
This PR adds compatibility with such ORMs