### PR TITLE
Feature/swagger ui behind proxy

### DIFF
--- a/flask_restplus/__about__.py
+++ b/flask_restplus/__about__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.12.2.dev-behind_proxy'
+__version__ = '0.12.3.dev'
 __description__ = 'Fully featured framework for fast, easy and documented API development with Flask'

--- a/flask_restplus/__about__.py
+++ b/flask_restplus/__about__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.12.2.dev'
+__version__ = '0.12.2.dev-behind_proxy'
 __description__ = 'Fully featured framework for fast, easy and documented API development with Flask'

--- a/flask_restplus/__about__.py
+++ b/flask_restplus/__about__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.12.3.dev'
+__version__ = '0.12.4.dev'
 __description__ = 'Fully featured framework for fast, easy and documented API development with Flask'

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -14,11 +14,6 @@ from collections import OrderedDict
 from functools import wraps, partial
 from types import MethodType
 
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse
-
 from flask import url_for, request, current_app
 from flask import make_response as original_flask_make_response
 from flask.helpers import _endpoint_from_view_func
@@ -460,12 +455,12 @@ class Api(object):
 
         :rtype: str
         '''
-        swagger_url = url_for(self.endpoint('specs'), _external=True)
         if self.behind_proxy:
-            # Extract relative URL.
-            url_parts = urlparse(swagger_url)
-            swagger_url = url_parts.path
-        return swagger_url
+            # Use relative URL.
+            external = False
+        else:
+            external = True
+        return url_for(self.endpoint('specs'), _external=external)
 
     @property
     def base_url(self):

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -462,16 +462,9 @@ class Api(object):
         '''
         swagger_url = url_for(self.endpoint('specs'), _external=True)
         if self.behind_proxy:
+            # Extract relative URL.
             url_parts = urlparse(swagger_url)
-
-            # Compose relative URL.
-            swagger_parts = [url_parts.path]
-            if url_parts.query != '':
-                swagger_parts = ['?', url_parts.query]
-            if url_parts.fragment != '':
-                swagger_parts = ['#', url_parts.fragment]
-            swagger_url = ''.join(swagger_parts)
-
+            swagger_url = url_parts.path
         return swagger_url
 
     @property


### PR DESCRIPTION
This branch adds a **behind_proxy=True** keyword parameter to the **flask_restplus.api.Api(..., behind_proxy=True)** object. Many users need a _reverse proxy_ like **nginx** to serve the REST API. In my case, I had to place the server inside a kubernetes **pod** & keep its **port** number.

I added appropriate unit tests to the **test_api.py** file. It considers both cases when **behind_proxy** is either **True** or **False**.  I assume that **SERVER_NAME** is set & has a defined **port**.

OTHER ISSUES: I did not want to fix these in this branch & make it change too much

* I had to `pip install wheel` to make the `invoke dist` work, which is not listed in the **requirements** directory. 
* I had to run `invoke assets` _before_ `invoke dist` so that the **Swagger UI** javascript gets into the **wheel**
* `invoke qa` shows many **mccabe complexity** violations (C901 flake8 warnings) that stop the build

The **C901 complexity** warnings mean no one can just run `inv all` to complete a build :(