### PR TITLE
fix list field accept dict parameter bug

### DIFF
--- a/flask_restplus/fields.py
+++ b/flask_restplus/fields.py
@@ -273,8 +273,11 @@ class List(Raw):
 
     def format(self, value):
         # Convert all instances in typed list to container type
-        if isinstance(value, set):
+        if isinstance(value, (set, tuple)):
             value = list(value)
+
+        if not isinstance(value, list):
+            raise MarshallingError('should be list')
 
         is_nested = isinstance(self.container, Nested) or type(self.container) is Raw
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -836,6 +836,13 @@ class ListFieldTest(BaseFieldTestMixin, FieldTestCase):
         expected = [OrderedDict([('name', 'John Doe')]), OrderedDict([('name', 'Jane Doe')])]
         self.assert_field(field, data, expected)
 
+    def test_format_error(self, api):
+        nested_fields = api.model('NestedModel', {'name': fields.String})
+        field = fields.List(fields.Nested(nested_fields))
+        value = {'name': 'John Doe', 'age': 42}
+        with pytest.raises(fields.MarshallingError):
+            field.format(value)
+
     def test_min_items(self):
         field = fields.List(fields.String, min_items=5)
         assert 'minItems' in field.__schema__


### PR DESCRIPTION
when I use List field with nested object field, I find out when the client pass the object filed(not as list), the parameter check didn't throw parameter error(400), so I got a json object in my view layer, that is not what I expected,  thus trigger a bug。