### PR TITLE
auto judge scheme of specs_url

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -451,7 +451,8 @@ class Api(object):
 
         :rtype: str
         '''
-        return url_for(self.endpoint('specs'), _external=True)
+        _scheme = request.headers.get('x-forwarded-proto', 'http')
+        return url_for(self.endpoint('specs'), _external=True, _scheme=_scheme)
 
     @property
     def base_url(self):
@@ -460,7 +461,8 @@ class Api(object):
 
         :rtype: str
         '''
-        return url_for(self.endpoint('root'), _external=True)
+        _scheme = request.headers.get('x-forwarded-proto', 'http')
+        return url_for(self.endpoint('root'), _external=True, _scheme=_scheme)
 
     @property
     def base_path(self):


### PR DESCRIPTION
fix API specs page MixedContentError when served over https.

![image](https://user-images.githubusercontent.com/8390109/53620752-12ea8680-3c2f-11e9-9cc0-0022ef98e98d.png)
