### PR TITLE
Fix a problem of operation expand.

### DIFF
--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, absolute_import
 
+from uuid import uuid1
+
 import itertools
 import re
 
@@ -352,7 +354,7 @@ class Swagger(object):
             'responses': self.responses_for(doc, method) or None,
             'summary': doc[method]['docstring']['summary'],
             'description': self.description_for(doc, method) or None,
-            'operationId': self.operation_id_for(doc, method),
+            'operationId': '%s-%s' % (self.operation_id_for(doc, method), str(uuid1())[:6]),
             'parameters': self.parameters_for(doc[method]) or None,
             'security': self.security_for(doc, method),
         }


### PR DESCRIPTION
Several operation tabs would be expanded by one expand operation in doc page when a namespace includes duplicate http methods, since they have the same operationId. So, I join it a random string generated by "str(uuid.uuid1())[:6]".