### PR TITLE
Fix missing skip_none for Polymorph field marshalling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 Current
 -------
 
+- Fix missing ``skip_none`` parameter support in Polymorph field
 - Ensure `basePath` is always a path
 
 0.12.1 (2018-09-28)

--- a/flask_restplus/fields.py
+++ b/flask_restplus/fields.py
@@ -681,7 +681,7 @@ class Polymorph(Nested):
         elif len(candidates) > 1:
             raise ValueError('Unable to determine a candidate for: ' + value.__class__.__name__)
         else:
-            return marshal(value, candidates[0].resolved, mask=self.mask, ordered=ordered)
+            return marshal(value, candidates[0].resolved, skip_none=self.skip_none, mask=self.mask, ordered=ordered)
 
     def resolve_ancestor(self, models):
         '''


### PR DESCRIPTION
It's a Nested field feature, but it is missing in the Polymorph subclass.