### PR TITLE
Hide Namespaces With All Hidden Resources

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Current
 
 - Fix `@api.expect(..., validate=False)` decorators for an :class:`Api` where `validate=True` is set on the constructor
 - Ensure `basePath` is always a path
+- Hide Namespaces with all hidden Resources from Swagger documentation
 
 0.12.1 (2018-09-28)
 -------------------

--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -132,6 +132,14 @@ def parse_docstring(obj):
     return parsed
 
 
+def is_hidden(resource):
+    '''
+    Determine whether a Resource has been hidden from Swagger documentation
+    i.e. by using Api.doc(False) decorator
+    '''
+    return hasattr(resource, "__apidoc__") and resource.__apidoc__ is False
+
+
 class Swagger(object):
     '''
     A Swagger documentation wrapper for an API instance.
@@ -224,7 +232,12 @@ class Swagger(object):
             tags.append(tag)
             by_name[tag['name']] = tag
         for ns in api.namespaces:
+            # hide namespaces without any Resources
             if not ns.resources:
+                continue
+            # hide namespaces with all Resources hidden from Swagger documentation
+            resources = (resource for resource, urls, kwargs in ns.resources)
+            if all(is_hidden(r) for r in resources):
                 continue
             if ns.name not in by_name:
                 tags.append({

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -297,6 +297,30 @@ class SwaggerTest(object):
         data = client.get_specs('')
         assert data['tags'] == [{'name': 'ns'}]
 
+    def test_specs_endpoint_namespace_all_resources_hidden(self, app, client):
+        api = restplus.Api(app)
+        ns = api.namespace('ns')
+
+        @ns.route('/test', endpoint='test', doc=False)
+        class TestResource(restplus.Resource):
+            def get(self):
+                return {}
+
+        @ns.route('/test2', endpoint='test2')
+        @ns.hide
+        class TestResource2(restplus.Resource):
+            def get(self):
+                return {}
+
+        @ns.route('/test3', endpoint='test3')
+        @ns.doc(False)
+        class TestResource3(restplus.Resource):
+            def get(self):
+                return {}
+
+        data = client.get_specs('')
+        assert data['tags'] == []
+
     def test_specs_authorizations(self, app, client):
         authorizations = {
             'apikey': {


### PR DESCRIPTION
Fixes #615

## Changes
Namespaces where all Resources are hidden:
- Are not added to the Swagger `tags` property
- Are not shown in the Swagger UI

## Steps to Test/Reproduce
Example from #615:
```python
from flask import Flask

from flask_restplus import Api, Namespace, Resource


app = Flask(__name__)
api = Api(app)

namespace_with_resources = Namespace("Resources")
api.add_namespace(namespace_with_resources)

# your example
@namespace_with_resources.route("/foo", doc=False)
class MyResource(Resource):
    def get(self):
        return "foo"


namespace_without_resources = Namespace("No Resources")
api.add_namespace(namespace_without_resources)


if __name__ == "__main__":
    app.run(port=8080)
```
Namespace without resources is no longer shown:
![image](https://user-images.githubusercontent.com/14834132/55982661-4b9b6800-5c91-11e9-89b1-129b52651a5a.png)
