### PR TITLE
Toggle Swagger UI Try it Out Feature

### DIFF
--- a/doc/swagger.rst
+++ b/doc/swagger.rst
@@ -934,6 +934,27 @@ you can register a custom view function with the :meth:`~Api.documentation` deco
     def custom_ui():
         return apidoc.ui_for(api)
 
+Configuring "Try it Out"
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, all paths and methods have a "Try it Out" button for performing API requests in the browser.
+These can be disable **per method** with the ``SWAGGER_SUPPORTED_SUBMIT_METHODS`` configuration option, 
+supporting the same values as the ``supportedSubmitMethods`` `Swagger UI parameter <https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md#network/>`_.
+
+.. code-block:: python
+
+    from flask import Flask
+    from flask_restplus import Api
+
+    app = Flask(__name__)
+
+    # disable Try it Out for all methods
+    app.config.SWAGGER_SUPPORTED_SUBMIT_METHODS = []
+
+    # enable Try it Out for specific methods
+    app.config.SWAGGER_SUPPORTED_SUBMIT_METHODS = ["get", "post"]
+
+    api = Api(app)
 
 Disabling the documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/flask_restplus/templates/swagger-ui.html
+++ b/flask_restplus/templates/swagger-ui.html
@@ -60,6 +60,9 @@
                 plugins: [
                     SwaggerUIBundle.plugins.DownloadUrl
                 ],
+                {% if config.SWAGGER_SUPPORTED_SUBMIT_METHODS is defined -%}
+                  supportedSubmitMethods: {{ config.SWAGGER_SUPPORTED_SUBMIT_METHODS | tojson}},
+                {%- endif %}
                 displayOperationId: {{ config.SWAGGER_UI_OPERATION_ID|default(False)|tojson }},
                 displayRequestDuration: {{ config.SWAGGER_UI_REQUEST_DURATION|default(False)|tojson }},
                 docExpansion: "{{ config.SWAGGER_UI_DOC_EXPANSION | default('none') }}"


### PR DESCRIPTION
## Motivation
Swagger UI by default provides a "Try it Out" button for all paths and methods. Some users have requested the ability to disable this feature for use in production environments - see issue #513.

## Changes

- [x]  Add a `SWAGGER_SUPPORTED_SUBMIT_METHODS` configuration option which takes the same values as the `supportedSubmitMethods` [Swagger UI configuration parameter](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md#network)


### Default (enabled for all):
![image](https://user-images.githubusercontent.com/14834132/57243341-d28ff600-702d-11e9-8013-9338864f1aee.png)
![image](https://user-images.githubusercontent.com/14834132/57243351-d6bc1380-702d-11e9-9080-97e3d508a224.png)
![image](https://user-images.githubusercontent.com/14834132/57243360-dc195e00-702d-11e9-8d78-33ca4d767637.png)
![image](https://user-images.githubusercontent.com/14834132/57243375-e2a7d580-702d-11e9-9348-b7175c250c68.png)

### `app.config.SWAGGER_SUPPORTED_SUBMIT_METHODS = []` (disabled for all):
![image](https://user-images.githubusercontent.com/14834132/57243405-f9e6c300-702d-11e9-9c2c-184d7e2ba7ff.png)
![image](https://user-images.githubusercontent.com/14834132/57243414-ff440d80-702d-11e9-8900-da5458b3b623.png)
![image](https://user-images.githubusercontent.com/14834132/57243425-03702b00-702e-11e9-8e3d-fd5b4b1039c2.png)
![image](https://user-images.githubusercontent.com/14834132/57243437-08cd7580-702e-11e9-9b26-8d95c1a87b3f.png)

### `app.config.SWAGGER_SUPPORTED_SUBMIT_METHODS = ["get", "post"]` (enabled for some):
![image](https://user-images.githubusercontent.com/14834132/57243467-20a4f980-702e-11e9-9960-f634e00c40f2.png)
![image](https://user-images.githubusercontent.com/14834132/57243475-24388080-702e-11e9-8614-7b255bf84b00.png)
![image](https://user-images.githubusercontent.com/14834132/57243481-27337100-702e-11e9-9ea2-4d3152a7ee0b.png)
![image](https://user-images.githubusercontent.com/14834132/57243485-2ac6f800-702e-11e9-81d5-29ef012d4982.png)

## Changes for Discussion
- Support per-route/namespace/method toggle via `doc` decorator? For example
```python
# disable for entire Resource
@api.doc(try_it_out=False)
@ns.route('/')
class TodoList(Resource):
    '''Shows a list of all todos, and lets you POST to add new tasks'''
    def get(self):
        '''List all tasks'''
        return DAO.todos

    def post(self):
        '''Create a new task'''
        return DAO.create(api.payload), 201

@ns.route('/<int:id>')
class Todo(Resource):
    '''Show a single todo item and lets you delete them'''
    # disable try it out just for this method
    @ns.doc('get_todo', try_it_out=False)
    def get(self, id):
        '''Fetch a given resource'''
        return DAO.get(id)
    # other methods still have try it out button
    def delete(self, id):
        '''Delete a task given its identifier'''
        DAO.delete(id)
        return '', 204

    def put(self, id):
        '''Update a task given its identifier'''
        return DAO.update(id, api.payload)
```