### PR TITLE
Json schema include nested models in register_model

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Current
 - Fix `@api.expect(..., validate=False)` decorators for an :class:`Api` where `validate=True` is set on the constructor (:issue:`609`, :pr:`610`)
 - Ensure `basePath` is always a path
 - Hide Namespaces with all hidden Resources from Swagger documentation
+- In register_model() when working with SchemaModel type, also recursively register nested models
 
 0.12.1 (2018-09-28)
 -------------------

--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -16,7 +16,7 @@ from flask import current_app
 from werkzeug.routing import parse_rule
 
 from . import fields
-from .model import Model, ModelBase
+from .model import SchemaModel, Model, ModelBase
 from .reqparse import RequestParser
 from .utils import merge, not_none, not_none_sorted
 from ._http import HTTPStatus
@@ -557,6 +557,12 @@ class Swagger(object):
         if isinstance(specs, Model):
             for field in itervalues(specs):
                 self.register_field(field)
+        if isinstance(specs, SchemaModel):
+            for prop in itervalues(specs._schema['properties']):
+                if ('$ref' in prop):
+                    name = prop['$ref'].rsplit('/', 1).pop()
+                    if name in self.api.models:
+                        self.register_model(self.api.models[name])
         return ref(model)
 
     def register_field(self, field):


### PR DESCRIPTION
When a SchemaModel type is created passing a Marshmallow schema into OpenAPIConverter.schema2jsonschema from the latest apispec.ext.marshmallow.openapi (and probably through other means), where a nested model is found it is referenced through a '$ref' key in the JSON with the value of "#/definitions/[submodel name]", where [submodel name] is the name given to the nested schema model. However, swagger does not add the nested schema model to the definitions, resulting in errors. This patch solves that problem by parsing out the referenced model name, finding that named model in api.models and registering that.

Tox and qa tasks are passing.