### PR TITLE
Add config option for showing/hiding models in documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Current
 - Fix `@api.expect(..., validate=False)` decorators for an :class:`Api` where `validate=True` is set on the constructor (:issue:`609`, :pr:`610`)
 - Ensure `basePath` is always a path
 - Hide Namespaces with all hidden Resources from Swagger documentation
+- Add `SWAGGER_DEFAULT_MODELS_EXPANSION_DEPTH` config option to hide/show models in Swagger documentation
 
 0.12.1 (2018-09-28)
 -------------------

--- a/doc/swagger.rst
+++ b/doc/swagger.rst
@@ -905,6 +905,21 @@ setting (``'none'``, ``'list'`` or ``'full'``):
 
     api = Api(app)
 
+
+By default, models are shown at the bottom. You can show/hide the models in the documentation with the
+``config.SWAGGER_DEFAULT_MODELS_EXPANSION_DEPTH`` setting (``1``, or ``-1``):
+
+.. code-block:: python
+
+    from flask import Flask
+    from flask_restplus import Api
+
+    app = Flask(__name__)
+    app.config.SWAGGER_DEFAULT_MODELS_EXPANSION_DEPTH = -1
+
+    api = Api(app)
+
+
 By default, operation ID is hidden as well as request duration, you can enable them respectively with:
 
 .. code-block:: python

--- a/flask_restplus/templates/swagger-ui.html
+++ b/flask_restplus/templates/swagger-ui.html
@@ -65,7 +65,8 @@
                 {%- endif %}
                 displayOperationId: {{ config.SWAGGER_UI_OPERATION_ID|default(False)|tojson }},
                 displayRequestDuration: {{ config.SWAGGER_UI_REQUEST_DURATION|default(False)|tojson }},
-                docExpansion: "{{ config.SWAGGER_UI_DOC_EXPANSION | default('none') }}"
+                docExpansion: "{{ config.SWAGGER_UI_DOC_EXPANSION | default('none') }}",
+                defaultModelsExpandDepth: {{ config.SWAGGER_DEFAULT_MODELS_EXPANSION_DEPTH | default(1) }}
             })
 
             {% if config.SWAGGER_UI_OAUTH_CLIENT_ID -%}

--- a/tests/test_apidoc.py
+++ b/tests/test_apidoc.py
@@ -63,6 +63,16 @@ class APIDocTest(object):
         response = client.get(url_for('doc'))
         assert 'docExpansion: "full"' in str(response.data)
 
+    def test_apidoc_defualt_models_expansion_depth_parameter(self, app, client):
+        restplus.Api(app)
+
+        response = client.get(url_for('doc'))
+        assert 'defaultModelsExpandDepth: 1' in str(response.data)
+
+        app.config['SWAGGER_DEFAULT_MODELS_EXPANSION_DEPTH'] = -1
+        response = client.get(url_for('doc'))
+        assert 'defaultModelsExpandDepth: -1' in str(response.data)
+
     def test_apidoc_doc_display_operation_id(self, app, client):
         restplus.Api(app)
 


### PR DESCRIPTION
This pull request addresses issue #583 