### PR TITLE
Add support for custom default model classes

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -87,6 +87,9 @@ class Api(object):
     :param FormatChecker format_checker: A jsonschema.FormatChecker object that is hooked into
         the Model validator. A default or a custom FormatChecker can be provided (e.g., with custom
         checkers), otherwise the default action is to not enforce any format validation.
+    :param type default_model_class: Class to use when invoking api.model(), defaults to Model
+    :param type default_ordered_model_class: Class to use when invoking api.model() in an ordered
+        namespace, defaults to OrderedModel
     '''
 
     def __init__(self, app=None, version='1.0', title=None, description=None,
@@ -97,6 +100,7 @@ class Api(object):
             tags=None, prefix='', ordered=False,
             default_mediatype='application/json', decorators=None,
             catch_all_404s=False, serve_challenge_on_401=False, format_checker=None,
+            default_model_class=None, default_ordered_model_class=None,
             **kwargs):
         self.version = version
         self.title = title or 'API'
@@ -131,6 +135,8 @@ class Api(object):
             validate=validate,
             api=self,
             path='/',
+            default_model_class=default_model_class,
+            default_ordered_model_class=default_ordered_model_class,
         )
         self.ns_paths = dict()
 

--- a/flask_restplus/namespace.py
+++ b/flask_restplus/namespace.py
@@ -28,10 +28,14 @@ class Namespace(object):
     :param list decorators: A list of decorators to apply to each resources
     :param bool validate: Whether or not to perform validation on this namespace
     :param bool ordered: Whether or not to preserve order on models and marshalling
+    :param type default_model_class: Class to use when invoking ns.model(), defaults to Model
+    :param type default_ordered_model_class: Class to use when invoking ns.model() in an
+        ordered namespace, default os OrderedModel
     :param Api api: an optional API to attache to the namespace
     '''
     def __init__(self, name, description=None, path=None, decorators=None, validate=None,
-            authorizations=None, ordered=False, **kwargs):
+            authorizations=None, ordered=False, default_model_class=None,
+            default_ordered_model_class=None, **kwargs):
         self.name = name
         self.description = description
         self._path = path
@@ -46,6 +50,8 @@ class Namespace(object):
         self.default_error_handler = None
         self.authorizations = authorizations
         self.ordered = ordered
+        self.default_model_class = default_model_class or Model
+        self.default_ordered_model_class = default_ordered_model_class or OrderedModel
         self.apis = []
         if 'api' in kwargs:
             self.apis.append(kwargs['api'])
@@ -144,7 +150,7 @@ class Namespace(object):
 
         .. seealso:: :class:`Model`
         '''
-        cls = OrderedModel if self.ordered else Model
+        cls = self.default_ordered_model_class if self.ordered else self.default_model_class
         model = cls(name, model, mask=mask)
         model.__apidoc__.update(kwargs)
         return self.add_model(name, model)

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -56,6 +56,22 @@ class NamespaceTest(object):
         assert 'Person' in api.models
         assert isinstance(api.models['Person'], OrderedModel)
 
+    def test_custom_model(self):
+        class CustomModel(Model):
+            pass
+        api = Namespace('test', default_model_class=CustomModel)
+        api.model('Person', {})
+        assert 'Person' in api.models
+        assert isinstance(api.models['Person'], CustomModel)
+
+    def test_custom_ordered_model(self):
+        class CustomOrderedModel(Model):
+            pass
+        api = Namespace('test', ordered=True, default_ordered_model_class=CustomOrderedModel)
+        api.model('Person', {})
+        assert 'Person' in api.models
+        assert isinstance(api.models['Person'], CustomOrderedModel)
+
     def test_schema_model(self):
         api = Namespace('test')
         api.schema_model('Person', {})
@@ -133,3 +149,22 @@ class NamespaceTest(object):
         client.post_json('/apples/validation/', data)
 
         assert Payload.payload == data
+
+
+class DefaultNamespaceTest(object):
+
+    def test_custom_model(self, app):
+        class CustomModel(Model):
+            pass
+        api = restplus.Api(app, default_model_class=CustomModel)
+        api.model('Person', {})
+        assert 'Person' in api.models
+        assert isinstance(api.models['Person'], CustomModel)
+
+    def test_custom_ordered_model(self, app):
+        class CustomOrderedModel(Model):
+            pass
+        api = restplus.Api(app, ordered=True, default_ordered_model_class=CustomOrderedModel)
+        api.model('Person', {})
+        assert 'Person' in api.models
+        assert isinstance(api.models['Person'], CustomOrderedModel)


### PR DESCRIPTION
By specifying default_model_class and/or default_ordered_model_class in
the Api or the Namespace, the according class will be used when using
the api/namespace.model() method.

resolves #647