### PR TITLE
Documentation: the parameter should be called readonly

### DIFF
--- a/doc/example.rst
+++ b/doc/example.rst
@@ -18,7 +18,7 @@ Here is a full example of a `TodoMVC <http://todomvc.com/>`_ API.
     ns = api.namespace('todos', description='TODO operations')
 
     todo = api.model('Todo', {
-        'id': fields.Integer(readOnly=True, description='The task unique identifier'),
+        'id': fields.Integer(readonly=True, description='The task unique identifier'),
         'task': fields.String(required=True, description='The task details')
     })
 


### PR DESCRIPTION
Problem is here
https://flask-restplus.readthedocs.io/en/stable/example.html

As per documentation here 

https://flask-restplus.readthedocs.io/en/stable/api.html#flask_restplus.fields.Raw

The field is called `readonly`, not `readOnly`.

This fails silently, leading to long sessions of debugging.