### PR TITLE
Multiple Routes Swagger Documentation 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Current
 - Fix `@api.expect(..., validate=False)` decorators for an :class:`Api` where `validate=True` is set on the constructor (:issue:`609`, :pr:`610`)
 - Ensure `basePath` is always a path
 - Hide Namespaces with all hidden Resources from Swagger documentation
+- Per route Swagger documentation for multiple routes on a ``Resource``
 
 0.12.1 (2018-09-28)
 -------------------

--- a/doc/swagger.rst
+++ b/doc/swagger.rst
@@ -355,6 +355,63 @@ For example, these two declarations are equivalent:
         def get(self, id):
             return {}
 
+Multiple Routes per Resource
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Multiple ``Api.route()`` decorators can be used to add multiple routes for a ``Resource``.
+The ``doc`` parameter provides documentation **per route**.
+
+For example, here the ``description`` is applied only to the ``/also-my-resource/<id>`` route:
+
+.. code-block:: python
+
+    @api.route("/my-resource/<id>")
+    @api.route(
+        "/also-my-resource/<id>",
+        doc={"description": "Alias for /my-resource/<id>"},
+    )
+    class MyResource(Resource):
+        def get(self, id):
+            return {}
+
+Here, the ``/also-my-resource/<id>`` route is marked as deprecated:
+
+.. code-block:: python
+
+    @api.route("/my-resource/<id>")
+    @api.route(
+        "/also-my-resource/<id>",
+        doc={
+            "description": "Alias for /my-resource/<id>, this route is being phased out in V2",
+            "deprecated": True,
+        },
+    )
+    class MyResource(Resource):
+        def get(self, id):
+            return {}
+
+Documentation applied to the ``Resource`` using ``Api.doc()`` is `shared` amongst all
+routes unless explicitly overridden:
+
+.. code-block:: python
+
+    @api.route("/my-resource/<id>")
+    @api.route(
+    "/also-my-resource/<id>",
+    doc={"description": "Alias for /my-resource/<id>"},
+    )
+    @api.doc(params={"id": "An ID", description="My resource"})
+    class MyResource(Resource):
+    def get(self, id):
+        return {}
+
+Here, the ``id`` documentation from the ``@api.doc()`` decorator is present in both routes, 
+``/my-resource/<id>`` inherits the ``My resource`` description from the ``@api.doc()`` 
+decorator and  ``/also-my-resource/<id>`` overrides the description with ``Alias for /my-resource/<id>``.
+
+Routes with a ``doc`` parameter are given a `unique` Swagger ``operationId``. Routes without
+``doc`` parameter have the same Swagger ``operationId`` as they are deemed the same operation.
+
 
 Documenting the fields
 ----------------------

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -268,6 +268,7 @@ class Api(object):
 
     def _register_view(self, app, resource, namespace, *urls, **kwargs):
         endpoint = kwargs.pop('endpoint', None) or camel_to_dash(resource.__name__)
+        kwargs.pop("doc", {})
         resource_class_args = kwargs.pop('resource_class_args', ())
         resource_class_kwargs = kwargs.pop('resource_class_kwargs', {})
 

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -268,7 +268,6 @@ class Api(object):
 
     def _register_view(self, app, resource, namespace, *urls, **kwargs):
         endpoint = kwargs.pop('endpoint', None) or camel_to_dash(resource.__name__)
-        kwargs.pop("doc", {})
         resource_class_args = kwargs.pop('resource_class_args', ())
         resource_class_kwargs = kwargs.pop('resource_class_kwargs', {})
 
@@ -422,8 +421,9 @@ class Api(object):
             if path is not None:
                 self.ns_paths[ns] = path
         # Register resources
-        for resource, urls, kwargs in ns.resources:
-            self.register_resource(ns, resource, *self.ns_urls(ns, urls), **kwargs)
+        for r in ns.resources:
+            urls = self.ns_urls(ns, r.urls)
+            self.register_resource(ns, r.resource, *urls, **r.kwargs)
         # Register models
         for name, definition in six.iteritems(ns.models):
             self.models[name] = definition

--- a/flask_restplus/namespace.py
+++ b/flask_restplus/namespace.py
@@ -90,6 +90,7 @@ class Namespace(object):
             if doc is not None:
                 route_doc = self._build_doc(cls, doc)
                 kwargs['doc'] = route_doc
+                cls.__apidoc__ = route_doc
             self.add_resource(cls, *urls, **kwargs)
             return cls
         return wrapper

--- a/flask_restplus/namespace.py
+++ b/flask_restplus/namespace.py
@@ -89,8 +89,8 @@ class Namespace(object):
             doc = kwargs.get('doc', None)
             if doc is not None:
                 route_doc = self._build_doc(cls, doc)
+                # TODO: CLEAN THIS UP + ADD MORE TESTS
                 kwargs['doc'] = route_doc
-                cls.__apidoc__ = route_doc
             self.add_resource(cls, *urls, **kwargs)
             return cls
         return wrapper

--- a/flask_restplus/namespace.py
+++ b/flask_restplus/namespace.py
@@ -58,7 +58,7 @@ class Namespace(object):
     def path(self):
         return (self._path or ('/' + self.name)).rstrip('/')
 
-    def add_resource(self, resource, *urls, route_doc=None, **kwargs):
+    def add_resource(self, resource, *urls, **kwargs):
         '''
         Register a Resource for a given API Namespace
 
@@ -80,7 +80,7 @@ class Namespace(object):
             namespace.add_resource(Foo, '/foo', endpoint="foo")
             namespace.add_resource(FooSpecial, '/special/foo', endpoint="foo")
         '''
-        route_doc = {} if route_doc is None else route_doc
+        route_doc = kwargs.pop('route_doc', {})
         self.resources.append(ResourceRoute(resource, urls, route_doc, kwargs))
         for api in self.apis:
             ns_urls = api.ns_urls(self, urls)

--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -366,7 +366,10 @@ class Swagger(object):
             methods = [m.lower() for m in kwargs.get('methods', [])]
             if doc[method] is False or methods and method not in methods:
                 continue
-            path[method] = self.serialize_operation(doc, method)
+            if route_doc and method in route_doc and route_doc[method] is not False:
+                path[method] = self.serialize_operation(route_doc, method)
+            else:
+                path[method] = self.serialize_operation(doc, method)
             path[method]['tags'] = [ns.name]
         return not_none(path)
 
@@ -411,7 +414,7 @@ class Swagger(object):
         '''Extract the description metadata and fallback on the whole docstring'''
         parts = []
         if 'description' in doc:
-            parts.append(doc['description'])
+            parts.append(doc['description'] or "")
         if method in doc and 'description' in doc[method]:
             parts.append(doc[method]['description'])
         if doc[method]['docstring']['details']:

--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -258,7 +258,15 @@ class Swagger(object):
         doc = merge(getattr(resource, '__apidoc__', {}), route_doc)
         if doc is False:
             return False
-        doc['name'] = resource.__name__
+
+        # ensure unique names for multiple routes to the same resource
+        # provides different Swagger operationId's
+        doc["name"] = (
+            "{}_{}".format(resource.__name__, url)
+            if route_doc
+            else resource.__name__
+        )
+
         params = merge(self.expected_params(doc), doc.get('params', OrderedDict()))
         params = merge(params, extract_path_params(url))
         # Track parameters for late deduplication

--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -353,6 +353,12 @@ class Swagger(object):
         doc = self.extract_resource_doc(resource, url)
         if doc is False:
             return
+        route_doc = kwargs.get("doc")
+        if route_doc is False:
+            return
+        elif route_doc:
+            doc = merge(doc, route_doc)
+
         path = {
             'parameters': self.parameters_for(doc) or None
         }

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -3094,11 +3094,11 @@ class SwaggerTest(object):
         assert path['get']['description'] == 'the same endpoint'
 
         path = data['paths']['/bar']
-        assert path['get']['description'] == 'an endpoint'
+        assert path['get']['description'] == 'the same endpoint'
 
     def test_routes_merge_doc(self, api, client):
         @api.route('/foo/bar', doc={'description': 'the same endpoint'})
-        @api.route('/bar')
+        @api.route('/bar', doc={'description': False})
         @api.doc(security=[{'oauth2': ['read', 'write']}])
         class TestResource(restplus.Resource):
             def get(self):

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -3094,7 +3094,7 @@ class SwaggerTest(object):
         assert path['get']['description'] == 'the same endpoint'
 
         path = data['paths']['/bar']
-        assert path['get']['description'] == 'the same endpoint'
+        assert path['get']['description'] == 'an endpoint'
 
     def test_routes_merge_doc(self, api, client):
         @api.route('/foo/bar', doc={'description': 'the same endpoint'})

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -3111,7 +3111,7 @@ class SwaggerTest(object):
         assert path['get']['security'] == [{'oauth2': ['read', 'write']}]
 
         path = data['paths']['/bar']
-        assert path['get']['description'] == restplus.swagger.DEFAULT_RESPONSE_DESCRIPTION
+        assert 'description' not in path['get']
         assert path['get']['security'] == [{'oauth2': ['read', 'write']}]
 
 


### PR DESCRIPTION
# Motivation
See #288 for initial issue. 

Using the `doc` parameter of `Api.route()` decorator applies documentation to the `Resource` as a whole. This prevents documentation being added on a per-route basis (for example adding an additional description to a route, or marking one route as deprecated) as the `doc` is applied to all routes.

Furthermore, each route uses the same Swagger `operationId`, causing both routes to be expanded at the same time when selecting one in the Swagger UI (the elements are selected using an HTML `id` which is set to the `operationId`.

# Changes
- Using the `doc` parameter `Api.route()` will apply the documentation to that route only
- Routes using the `doc` parameter are given unique `operationId`s (combining the original `operationId` with the URLs provided)
- Each route will inherit documentation from the `Resource` (i.e. if applied using `@api.doc`, unless explicitly overridden with the `doc` parameter

# Examples

## Providing a `description` to a single route:

```python
@api.route("/my-resource/<id>")
@api.route(
    "/also-my-resource/<id>",
    doc={"description": "Alias for /my-resource/<id>"},
)

class MyResource(Resource):
    def get(self, id):
        return {}
```
![single_route_1](https://user-images.githubusercontent.com/14834132/60156085-98e49b80-97e3-11e9-9aac-3508e770b2f0.png)

Expanding the first route only (note the `description`):
![single_route_2](https://user-images.githubusercontent.com/14834132/60156102-a3069a00-97e3-11e9-94bd-4f4bd74a185a.png)

Expanding the second route only (note lack of `description`):
![single_route_3](https://user-images.githubusercontent.com/14834132/60156113-abf76b80-97e3-11e9-9144-56f9167f5f49.png)

## Inheriting/overriding from the `Resource` 
```python
@api.route('/my-resource/<id>', '/test/<id>')
@api.route('/also-my-resource/<id>', doc={"description": "Alias for /my-resource/<id>"})
@api.doc(params={'id': 'An ID'}, description="My resource")
class MyResource(Resource):
    def get(self, id):
        return {}
```
![image](https://user-images.githubusercontent.com/14834132/60156307-232cff80-97e4-11e9-931f-aa7fac8ef8f0.png)

Expanding the first route only (note `id` parameter from ``@api.doc()`` but overridden `description`)
![image](https://user-images.githubusercontent.com/14834132/60156331-2fb15800-97e4-11e9-92b8-3651039712fe.png)

Expanding the second route only (note `id` parameter and `description` inherited from `@api.doc()` decorator):
![image](https://user-images.githubusercontent.com/14834132/60156360-43f55500-97e4-11e9-923a-f3350f10c193.png)

Various combinations of the above can be used with of the available documentation parameters (`description`, `id`, `params`, `deprecated` etc).
