### PR TITLE
Makes the example of a field accepts the falsy values

### DIFF
--- a/flask_restplus/fields.py
+++ b/flask_restplus/fields.py
@@ -120,7 +120,7 @@ class Raw(object):
         self.description = description
         self.required = required
         self.readonly = readonly
-        self.example = example or self.__schema_example__
+        self.example = example if example is not None else self.__schema_example__
         self.mask = mask
 
     def format(self, value):


### PR DESCRIPTION
It enables to pass falsy values like **False, "" and empty list.**

example:
`fieldName: fields.String(example="")`