### PR TITLE
Issue ordered api nested model problems

### DIFF
--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -16,7 +16,7 @@ from flask import current_app
 from werkzeug.routing import parse_rule
 
 from . import fields
-from .model import Model, ModelBase
+from .model import Model, OrderedModel, ModelBase
 from .reqparse import RequestParser
 from .utils import merge, not_none, not_none_sorted
 from ._http import HTTPStatus
@@ -50,7 +50,7 @@ RE_RAISES = re.compile(r'^:raises\s+(?P<name>[\w\d_]+)\s*:\s*(?P<description>.*)
 
 def ref(model):
     '''Return a reference to model in definitions'''
-    name = model.name if isinstance(model, ModelBase) else model
+    name = model.name if isinstance(model, (ModelBase, OrderedModel)) else model
     return {'$ref': '#/definitions/{0}'.format(name)}
 
 
@@ -578,7 +578,7 @@ class Swagger(object):
         if isinstance(specs, ModelBase):
             for parent in specs.__parents__:
                 self.register_model(parent)
-        if isinstance(specs, Model):
+        if isinstance(specs, (Model, OrderedModel)):
             for field in itervalues(specs):
                 self.register_field(field)
         return ref(model)

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -1597,6 +1597,10 @@ class SwaggerTest(object):
         assert path['get']['responses']['200']['schema']['$ref'] == '#/definitions/Person'
         assert path['post']['responses']['200']['schema']['$ref'] == '#/definitions/Person'
 
+    @pytest.mark.api(ordered=True)
+    def test_model_as_nested_dict_with_api_ordered(self, api, client):
+        self.test_model_as_nested_dict(api, client)
+
     def test_model_as_nested_dict_with_details(self, api, client):
         address_fields = api.model('Address', {
             'road': restplus.fields.String,
@@ -1640,6 +1644,10 @@ class SwaggerTest(object):
             },
             'type': 'object'
         }
+
+    @pytest.mark.api(ordered=True)
+    def test_model_as_nested_dict_with_details_with_api_ordered(self, api, client):
+        self.test_model_as_nested_dict_with_details(api, client)
 
     def test_model_as_flat_dict_with_marchal_decorator(self, api, client):
         fields = api.model('Person', {
@@ -1878,6 +1886,10 @@ class SwaggerTest(object):
         assert 'definitions' in data
         assert 'Person' in data['definitions']
         assert 'Address' in data['definitions']
+
+    @pytest.mark.api(ordered=True)
+    def test_model_as_nested_dict_with_list_with_api_ordered(self, api, client):
+        self.test_model_as_nested_dict_with_list(api, client)
 
     def test_model_list_of_primitive_types(self, api, client):
         @api.route('/model-list/')
@@ -2191,6 +2203,10 @@ class SwaggerTest(object):
             }]
         }
 
+    @pytest.mark.api(ordered=True)
+    def test_inherit_inline_with_api_ordered(self, api, client):
+        self.test_inherit_inline(api, client)
+
     def test_polymorph_inherit(self, api, client):
         class Child1:
             pass
@@ -2297,6 +2313,10 @@ class SwaggerTest(object):
             }]
         }
 
+    @pytest.mark.api(ordered=True)
+    def test_polymorph_inherit_with_api_ordered(self, api, client):
+        self.test_polymorph_inherit_list(api, client)
+
     def test_expect_model(self, api, client):
         person = api.model('Person', {
             'name': restplus.fields.String,
@@ -2343,6 +2363,10 @@ class SwaggerTest(object):
             }
         }
         assert 'description' not in parameter
+
+    @pytest.mark.api(ordered=True)
+    def test_polymorph_inhert_list_with_api_ordered(self, api, client):
+        self.test_polymorph_inherit_list(api, client)
 
     def test_body_model_shortcut(self, api, client):
         fields = api.model('Person', {


### PR DESCRIPTION
Hi maintainers, 

I spent a day figuring this out and generating a PR before noticing it partially duplicates the work for another PR #616.
However, my PR also includes test functions in test_swagger.py that fail pre-patch.
The new tests just create an ordered restplus.Api object for the 6 tests that failed when I set that globally during local testing.
If you accept this PR then you get test coverage too!

Cheers

Ben