### PR TITLE
Fix ambiguity error with Polymorphism candidates (isinstance() problem)

### DIFF
--- a/flask_restplus/fields.py
+++ b/flask_restplus/fields.py
@@ -674,7 +674,7 @@ class Polymorph(Nested):
         if not hasattr(value, '__class__'):
             raise ValueError('Polymorph field only accept class instances')
 
-        candidates = [fields for cls, fields in iteritems(self.mapping) if isinstance(value, cls)]
+        candidates = [fields for cls, fields in iteritems(self.mapping) if value.__class__.__name__ == cls.__name__]
 
         if len(candidates) <= 0:
             raise ValueError('Unknown class: ' + value.__class__.__name__)


### PR DESCRIPTION
Right now Polymorphism fails when using something like this (models in sqlalchemy):

models:

```python
class Product(BaseModel):
	discr = Column(String)

	__mapper_args__ = {
		'polymorphic_on': discr,
        'polymorphic_identity': "product"
	}

class VegetableProduct(Product):
	name = Column(String)

    __mapper_args__ = {
		'polymorphic_identity': "vegetable"
	}

class DairyProduct(VegetableProduct):
    __mapper_args__ = {
		'polymorphic_identity': "dairy"
	}
```

mapper:

```python
resource_product = api.model("Product", {
	'discr': fields.String
})

product_mapper = {
	VegetableProduct: api.inherit("Vegetable", resource_product, { 'name': fields.String }),
	DairyProduct: api.inherit("Dairy", resource_product, { 'name': fields.String }),
}

resource_result = api.model("ResourceResult", {
	'products': fields.List(fields.Polymorphism(product_mapper))
})
```

This sparkles error here:

https://github.com/noirbizarre/flask-restplus/blob/master/flask_restplus/fields.py#L682

Because candidates will be: VegetableProduct and DairyProduct, since isinstance() will return True for both classes (I personally surprised it works like this)

But actually it should be only DairyProduct

Checking by ```__class__.__name__``` removes this error and it works as intended.

I hope my quick fix did not break anything, I'm eager to update it if I don't know, more elegant solution is needed.