### PR TITLE
Fix error handler exception suppression

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 Current
 -------
 
-- Nothing yet
+- Ensure that exceptions raised in error handler, including programming errors, are logged (:issue:`705`, :pr:`706`)
 
 0.13.0 (2019-08-12)
 -------------------

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -579,8 +579,8 @@ class Api(object):
         if self._has_fr_route():
             try:
                 return self.handle_error(e)
-            except Exception:
-                pass  # Fall through to original handler
+            except Exception as f:
+                return original_handler(f)
         return original_handler(e)
 
     def handle_error(self, e):


### PR DESCRIPTION
This PR changes the `Api.error_router` so that it does not suppress exceptions which are raised in the implementation of error handling functions associated with Apis or Namespaces. Currently, buggy error handler implementations are unnecessarily difficult to diagnose and fix because any exceptions raised (other than the original exception being handled by the error handler) are suppressed. They do not appear in the log output, and do not cause a 500 Internal Server Error when they should.

With this changes, such errors – which are usually programming errors – are properly logged and give an appropriate response.

This PR is a direct response to #705 