### PR TITLE
Fixing Swagger Issue when using @api.expect() on a request parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ doc/_build/
 # Specifics
 flask_restplus/static
 node_modules
+
+# PyCharm
+.idea*

--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -143,6 +143,31 @@ def is_hidden(resource, route_doc=None):
         return hasattr(resource, "__apidoc__") and resource.__apidoc__ is False
 
 
+def rparser_to_swagger_body_param(request_parser):
+    """
+    If any parameters are in the request body then return the swagger representation for the requests json body
+    :param request_parser: The request parser containing params for the request
+    :return:
+    """
+    json_body_list = [p for p in request_parser.__schema__ if p['in'] == 'body']
+    if not json_body_list:
+        return
+
+    properties = {}
+    for param in json_body_list:
+        properties[param['name']] = {
+            'type': 'string' if 'type' not in param else param['type']
+        }
+
+    return {
+        'name': 'payload',
+        'required': True,
+        'in': 'body',
+        'type': 'object',
+        'schema': {'properties': properties}
+    }
+
+
 class Swagger(object):
     '''
     A Swagger documentation wrapper for an API instance.
@@ -329,8 +354,12 @@ class Swagger(object):
 
         for expect in doc.get('expect', []):
             if isinstance(expect, RequestParser):
-                parser_params = OrderedDict((p['name'], p) for p in expect.__schema__)
+                parser_params = OrderedDict((p['name'], p) for p in expect.__schema__ if p['in'] != 'body')
                 params.update(parser_params)
+
+                payload = rparser_to_swagger_body_param(expect)
+                if payload:
+                    params['payload'] = payload
             elif isinstance(expect, ModelBase):
                 params['payload'] = not_none({
                     'name': 'payload',


### PR DESCRIPTION
Below is a request parser for a simple hello world server.

```python
parser = reqparse.RequestParser()
parser.add_argument('test', type=int, location='json')
parser.add_argument('test1', location='json')
```

The resulting swagger JSON for these parameters is 

```json
"parameters": [
    {
         "name": "test",
          "in": "body",
          "type": "integer"
     },
     {
          "name": "test1",
           "in": "body",
           "type": "string"
       }
]
```

The result should be something similar to when a user provides a model with api.expect()

```json
"parameters": [
    {
        "name": "payload",
        "required": true,
        "in": "body",
        "schema": {
            "properties": {
                "test": {
                    "type": "integer"
                },
                "test1": {
                    "type": "string"
                }
            }
        }
    }
]
```

These changes fix that bug.