### PR TITLE
Fix passing of kwargs to `init_app`

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -149,7 +149,7 @@ class Api(object):
 
         if app is not None:
             self.app = app
-            self.init_app(app)
+            self.init_app(app, **kwargs)
         # super(Api, self).__init__(app, **kwargs)
 
     def init_app(self, app, **kwargs):


### PR DESCRIPTION
initiating app instance with arguments does not take effect,
```
api = Api(app, add_specs=False)
```

but when using the lazy instantiation it works

```
api = Api()
api.init_app(app, add_specs=False)
```