### PR TITLE
Import the ABCs from 'collections.abc' instead of 'collections'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Current
 -------
 
 - Ensure that exceptions raised in error handler, including programming errors, are logged (:issue:`705`, :pr:`706`)
+- Import the ABCs from 'collections.abc' instead of 'collections' by default as it is deprecated since Python3.7, and in 3.8 it will stop working. Python2.7 is still supported though.
 
 0.13.0 (2019-08-12)
 -------------------

--- a/doc/marshalling.rst
+++ b/doc/marshalling.rst
@@ -257,15 +257,11 @@ with other fields, you may want to use an ``OrderedDict`` and use the
 :class:`~fields.Wildcard` as the last field ::
 
     >>> from flask_restplus import fields, marshal
-    >>> from collections import OrderedDict
     >>> import json
     >>>
     >>> wild = fields.Wildcard(fields.Integer)
-    >>> mod = OrderedDict()
-    >>> mod['zoro'] = fields.String
-    >>> mod['*'] = wild
     >>> # you can use it in api.model like this:
-    >>> # some_fields = api.model('MyModel', mod)
+    >>> # some_fields = api.model('MyModel', {'zoro': fields.String, '*': wild})
     >>>
     >>> data = {'John': 12, 'bob': 42, 'Jane': '68', 'zoro': 72}
     >>> json.dumps(marshal(data, mod))

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -260,8 +260,6 @@ you use the ``fields`` module to describe the structure of your response.
 
 .. code-block:: python
 
-    from collections import OrderedDict
-
     from flask import Flask
     from flask_restplus import fields, Api, Resource
 

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -10,7 +10,11 @@ import re
 import six
 import sys
 
-from collections import OrderedDict
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    # TODO Remove this to drop Python2 support
+    from collections import OrderedDict
 from functools import wraps, partial
 from types import MethodType
 

--- a/flask_restplus/marshalling.py
+++ b/flask_restplus/marshalling.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from collections import OrderedDict
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    # TODO Remove this to drop Python2 support
+    from collections import OrderedDict
 from functools import wraps
 from six import iteritems
 

--- a/flask_restplus/mask.py
+++ b/flask_restplus/mask.py
@@ -5,7 +5,11 @@ import logging
 import re
 import six
 
-from collections import OrderedDict
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    # TODO Remove this to drop Python2 support
+    from collections import OrderedDict
 from inspect import isclass
 
 from .errors import RestError

--- a/flask_restplus/model.py
+++ b/flask_restplus/model.py
@@ -5,7 +5,11 @@ import copy
 import re
 import warnings
 
-from collections import OrderedDict, MutableMapping
+try:
+    from collections.abc import OrderedDict, MutableMapping
+except ImportError:
+    # TODO Remove this to drop Python2 support
+    from collections import OrderedDict, MutableMapping
 from six import iteritems, itervalues
 from werkzeug.utils import cached_property
 

--- a/flask_restplus/schemas/__init__.py
+++ b/flask_restplus/schemas/__init__.py
@@ -11,8 +11,11 @@ import io
 import json
 import pkg_resources
 
-from collections import Mapping
-
+try:
+    from collections.abc import Mapping
+except ImportError:
+    # TODO Remove this to drop Python2 support
+    from collections import Mapping
 from jsonschema import Draft4Validator
 
 from flask_restplus import errors

--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -5,11 +5,11 @@ import itertools
 import re
 
 from inspect import isclass, getdoc
-from collections import OrderedDict
 try:
-    from collections.abc import Hashable
+    from collections.abc import OrderedDict, Hashable
 except ImportError:
-    from collections import Hashable
+    # TODO Remove this to drop Python2 support
+    from collections import OrderedDict, Hashable
 from six import string_types, itervalues, iteritems, iterkeys
 
 from flask import current_app

--- a/flask_restplus/utils.py
+++ b/flask_restplus/utils.py
@@ -3,7 +3,11 @@ from __future__ import unicode_literals
 
 import re
 
-from collections import OrderedDict
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    # TODO Remove this to drop Python2 support
+    from collections import OrderedDict
 from copy import deepcopy
 from six import iteritems
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from collections import OrderedDict
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    # TODO Remove this to drop Python2 support
+    from collections import OrderedDict
 from datetime import date, datetime
 from decimal import Decimal
 from functools import partial

--- a/tests/test_fields_mask.py
+++ b/tests/test_fields_mask.py
@@ -4,7 +4,11 @@ from __future__ import unicode_literals
 import json
 import pytest
 
-from collections import OrderedDict
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    # TODO Remove this to drop Python2 support
+    from collections import OrderedDict
 
 from flask_restplus import mask, Api, Resource, fields, marshal, Mask
 

--- a/tests/test_marshalling.py
+++ b/tests/test_marshalling.py
@@ -7,7 +7,11 @@ from flask_restplus import (
     marshal, marshal_with, marshal_with_field, fields, Api, Resource
 )
 
-from collections import OrderedDict
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    # TODO Remove this to drop Python2 support
+    from collections import OrderedDict
 
 
 # Add a dummy Resource to verify that the app is properly set.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,7 +4,11 @@ from __future__ import unicode_literals
 import copy
 import pytest
 
-from collections import OrderedDict
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    # TODO Remove this to drop Python2 support
+    from collections import OrderedDict
 
 from flask_restplus import fields, Model, OrderedModel, SchemaModel
 


### PR DESCRIPTION
Import the ABCs from 'collections.abc' instead of 'collections' by default as it is deprecated since Python3.7, and in 3.8 it will stop working.

I considered that Python3 is the de-facto standard as Python2 support is being dropped in every other Python project and support ends at end of year. This is why I removed the OrderedDict sample and use a builtin dict instead of they are ordered since 3.6

I however kept Python2 support in the unlikely event that some projects are still upgrading flask-restplus dependency while not upgrading to Python3.

I did not add any additional test case as I assume the test suite runs with Python2 as well as 3.X, if this is not the case I am more than happy to remove the extra TODO and try/except blocks in this PR.

closes #727 