### PR TITLE
fix: make Wildcard fields support Nested and List fields (fix #728)

### DIFF
--- a/flask_restplus/fields.py
+++ b/flask_restplus/fields.py
@@ -281,9 +281,11 @@ class List(Raw):
         def is_attr(val):
             return self.container.attribute and hasattr(val, self.container.attribute)
 
+        if value is None:
+            return []
         return [
             self.container.output(idx,
-                val if (isinstance(val, dict) or is_attr(val)) and not is_nested else value)
+                                  val if (isinstance(val, dict) or is_attr(val)) and not is_nested else value)
             for idx, val in enumerate(value)
         ]
 
@@ -793,6 +795,8 @@ class Wildcard(Raw):
                 return self.container.format(self.default)
             return None
 
+        if isinstance(self.container, Nested):
+            return marshal(value, self.container.nested, skip_none=self.container.skip_none, ordered=ordered)
         return self.container.format(value)
 
     def schema(self):

--- a/tests/test_marshalling.py
+++ b/tests/test_marshalling.py
@@ -25,6 +25,37 @@ class MarshallingTest(object):
         assert not isinstance(output, OrderedDict)
         assert output == {'foo': 'bar'}
 
+    def test_marshal_wildcard_nested(self):
+        nest = fields.Nested(OrderedDict([('thumbnail', fields.String), ('video', fields.String)]))
+        wild = fields.Wildcard(nest)
+        wildcard_fields = OrderedDict([('*', wild)])
+        model = OrderedDict([('preview', fields.Nested(wildcard_fields))])
+        sub_dict = OrderedDict([
+            ('9:16', {'thumbnail': 24, 'video': 12}),
+            ('16:9', {'thumbnail': 25, 'video': 11}),
+            ('1:1', {'thumbnail': 26, 'video': 10})
+        ])
+        marshal_dict = OrderedDict([('preview', sub_dict)])
+        output = marshal(marshal_dict, model)
+        assert output == {'preview': {'1:1': {'thumbnail': '26', 'video': '10'},
+                                      '16:9': {'thumbnail': '25', 'video': '11'},
+                                      '9:16': {'thumbnail': '24', 'video': '12'}}}
+
+    def test_marshal_wildcard_list(self):
+        wild = fields.Wildcard(fields.List(fields.String))
+        wildcard_fields = OrderedDict([('*', wild)])
+        model = OrderedDict([('preview', fields.Nested(wildcard_fields))])
+        sub_dict = OrderedDict([
+            ('1:1', [1, 2, 3]),
+            ('16:9', [4, 5, 6]),
+            ('9:16', [7, 8, 9])
+        ])
+        marshal_dict = OrderedDict([('preview', sub_dict)])
+        output = marshal(marshal_dict, model)
+        assert output == {'preview': {'9:16': ['7', '8', '9'],
+                                      '16:9': ['4', '5', '6'],
+                                      '1:1': ['1', '2', '3']}}
+
     def test_marshal_with_envelope(self):
         model = OrderedDict([('foo', fields.Raw)])
         marshal_dict = OrderedDict([('foo', 'bar'), ('bat', 'baz')])


### PR DESCRIPTION
This allows you to use `fields.Nested` or `fields.List` as Wildcard inner fields.