### PR TITLE
Don't return exception when errorhandler is set (fix #693)

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -593,7 +593,12 @@ class Api(object):
         '''
         got_request_exception.send(current_app._get_current_object(), exception=e)
 
-        if not isinstance(e, HTTPException) and current_app.propagate_exceptions:
+        # When propagate_exceptions is set, do not return the exception to the
+        # client if a handler is configured for the exception.
+        if not isinstance(e, HTTPException) and \
+                current_app.propagate_exceptions and \
+                not isinstance(e, tuple(self.error_handlers.keys())):
+
             exc_type, exc_value, tb = sys.exc_info()
             if exc_value is e:
                 raise

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -637,3 +637,28 @@ class ErrorsTest(object):
                 '$ref': '#/responses/CustomException'
             }
         }
+
+    def test_errorhandler_with_propagate_true(self, app, client):
+        '''Exceptions with errorhandler should not be returned to client, even
+        if PROPAGATE_EXCEPTIONS is set.'''
+        app.config['PROPAGATE_EXCEPTIONS'] = True
+        api = restplus.Api(app)
+
+        @api.route('/test/', endpoint='test')
+        class TestResource(restplus.Resource):
+            def get(self):
+                raise RuntimeError('error')
+
+        @api.errorhandler(RuntimeError)
+        def handle_custom_exception(error):
+            return {'message': str(error), 'test': 'value'}, 400
+
+        response = client.get('/test/')
+        assert response.status_code == 400
+        assert response.content_type == 'application/json'
+
+        data = json.loads(response.data.decode('utf8'))
+        assert data == {
+            'message': 'error',
+            'test': 'value',
+        }


### PR DESCRIPTION
If errorhandler is configured, error should not be returned to client
even if PROPAGATE_EXCEPTIONS is true.