### PR TITLE
This code addresses custom validation on per-field basis

### DIFF
--- a/flask_restplus/model.py
+++ b/flask_restplus/model.py
@@ -99,6 +99,16 @@ class ModelBase(object):
         return model
 
     def validate(self, data, resolver=None, format_checker=None):
+        try:
+            # check if any field has a custom validator
+            current_field = ''
+            for field, value in data.items():
+                current_field = field
+                if hasattr(self.get(field), 'validate'):
+                    self[field].validate(value)
+        except Exception as e:
+            abort(HTTPStatus.BAD_REQUEST, message='Input payload validation failed',
+                errors={current_field: str(e)})
         validator = Draft4Validator(self.__schema__, resolver=resolver, format_checker=format_checker)
         try:
             validator.validate(data)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -618,10 +618,11 @@ class ModelTest(object):
         # format property and throws an error if invalid
         with pytest.raises(BadRequest):
             model.validate(data, format_checker=FormatChecker())
-    
+
     def test_custom_validate(self):
         class MyField(fields.Raw):
             __schema_type__ = 'string'
+
             def validate(self, value):
                 if value != 'correct':
                     raise fields.MarshallingError('Invalid Value')
@@ -632,6 +633,7 @@ class ModelTest(object):
         assert model.validate(good_data) is None
         with pytest.raises(Exception):
             model.validate(bad_data)
+
 
 class ModelSchemaTestCase(object):
     def test_model_schema(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -618,7 +618,20 @@ class ModelTest(object):
         # format property and throws an error if invalid
         with pytest.raises(BadRequest):
             model.validate(data, format_checker=FormatChecker())
-
+    
+    def test_custom_validate(self):
+        class MyField(fields.Raw):
+            __schema_type__ = 'string'
+            def validate(self, value):
+                if value != 'correct':
+                    raise fields.MarshallingError('Invalid Value')
+                return True
+        model = Model('MyModel', {'field': MyField()})
+        bad_data = {'field': 'incorrect'}
+        good_data = {'field': 'correct'}
+        assert model.validate(good_data) is None
+        with pytest.raises(Exception):
+            model.validate(bad_data)
 
 class ModelSchemaTestCase(object):
     def test_model_schema(self):


### PR DESCRIPTION
The #716 issue is addressed in this PR. Each field can specify its own validate() method and raise an exception producing appropriate error message.