### PR TITLE
throw exception instead of abort for validate request

### DIFF
--- a/flask_restplus/model.py
+++ b/flask_restplus/model.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from werkzeug import exceptions
 
 import copy
 import re
@@ -103,8 +104,8 @@ class ModelBase(object):
         try:
             validator.validate(data)
         except ValidationError:
-            abort(HTTPStatus.BAD_REQUEST, message='Input payload validation failed',
-                  errors=dict(self.format_error(e) for e in validator.iter_errors(data)))
+            errors = dict(self.format_error(e) for e in validator.iter_errors(data))
+            raise exceptions.BadRequest(errors)
 
     def format_error(self, error):
         path = list(error.path)

--- a/flask_restplus/reqparse.py
+++ b/flask_restplus/reqparse.py
@@ -364,7 +364,7 @@ class RequestParser(object):
             if found or arg.store_missing:
                 result[arg.dest or arg.name] = value
         if errors:
-            abort(HTTPStatus.BAD_REQUEST, 'Input payload validation failed', errors=errors)
+            raise exceptions.BadRequest(errors)
 
         if strict and req.unparsed_arguments:
             arguments = ', '.join(req.unparsed_arguments.keys())


### PR DESCRIPTION
I think this library is for the API, so returning the error format should be user-editable, so I think that instead of aborting, we should throw the exception better, They can catch the case this and return with their own format, please see my pull request