### PR TITLE
Fix OrderedDict import from collections instead of collections.abc

### DIFF
--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -10,11 +10,7 @@ import re
 import six
 import sys
 
-try:
-    from collections.abc import OrderedDict
-except ImportError:
-    # TODO Remove this to drop Python2 support
-    from collections import OrderedDict
+from collections import OrderedDict
 from functools import wraps, partial
 from types import MethodType
 

--- a/flask_restplus/marshalling.py
+++ b/flask_restplus/marshalling.py
@@ -1,11 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-try:
-    from collections.abc import OrderedDict
-except ImportError:
-    # TODO Remove this to drop Python2 support
-    from collections import OrderedDict
+from collections import OrderedDict
 from functools import wraps
 from six import iteritems
 

--- a/flask_restplus/mask.py
+++ b/flask_restplus/mask.py
@@ -5,11 +5,7 @@ import logging
 import re
 import six
 
-try:
-    from collections.abc import OrderedDict
-except ImportError:
-    # TODO Remove this to drop Python2 support
-    from collections import OrderedDict
+from collections import OrderedDict
 from inspect import isclass
 
 from .errors import RestError

--- a/flask_restplus/model.py
+++ b/flask_restplus/model.py
@@ -6,10 +6,11 @@ import re
 import warnings
 
 try:
-    from collections.abc import OrderedDict, MutableMapping
+    from collections.abc import MutableMapping
 except ImportError:
     # TODO Remove this to drop Python2 support
-    from collections import OrderedDict, MutableMapping
+    from collections import MutableMapping
+from collections import OrderedDict
 from six import iteritems, itervalues
 from werkzeug.utils import cached_property
 

--- a/flask_restplus/swagger.py
+++ b/flask_restplus/swagger.py
@@ -6,10 +6,11 @@ import re
 
 from inspect import isclass, getdoc
 try:
-    from collections.abc import OrderedDict, Hashable
+    from collections.abc import Hashable
 except ImportError:
     # TODO Remove this to drop Python2 support
-    from collections import OrderedDict, Hashable
+    from collections import Hashable
+from collections import OrderedDict
 from six import string_types, itervalues, iteritems, iterkeys
 
 from flask import current_app

--- a/flask_restplus/utils.py
+++ b/flask_restplus/utils.py
@@ -3,11 +3,7 @@ from __future__ import unicode_literals
 
 import re
 
-try:
-    from collections.abc import OrderedDict
-except ImportError:
-    # TODO Remove this to drop Python2 support
-    from collections import OrderedDict
+from collections import OrderedDict
 from copy import deepcopy
 from six import iteritems
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,11 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-try:
-    from collections.abc import OrderedDict
-except ImportError:
-    # TODO Remove this to drop Python2 support
-    from collections import OrderedDict
+from collections import OrderedDict
 from datetime import date, datetime
 from decimal import Decimal
 from functools import partial

--- a/tests/test_fields_mask.py
+++ b/tests/test_fields_mask.py
@@ -4,11 +4,7 @@ from __future__ import unicode_literals
 import json
 import pytest
 
-try:
-    from collections.abc import OrderedDict
-except ImportError:
-    # TODO Remove this to drop Python2 support
-    from collections import OrderedDict
+from collections import OrderedDict
 
 from flask_restplus import mask, Api, Resource, fields, marshal, Mask
 

--- a/tests/test_marshalling.py
+++ b/tests/test_marshalling.py
@@ -7,11 +7,7 @@ from flask_restplus import (
     marshal, marshal_with, marshal_with_field, fields, Api, Resource
 )
 
-try:
-    from collections.abc import OrderedDict
-except ImportError:
-    # TODO Remove this to drop Python2 support
-    from collections import OrderedDict
+from collections import OrderedDict
 
 
 # Add a dummy Resource to verify that the app is properly set.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,11 +4,7 @@ from __future__ import unicode_literals
 import copy
 import pytest
 
-try:
-    from collections.abc import OrderedDict
-except ImportError:
-    # TODO Remove this to drop Python2 support
-    from collections import OrderedDict
+from collections import OrderedDict
 
 from flask_restplus import fields, Model, OrderedModel, SchemaModel
 


### PR DESCRIPTION
Import `OrderedDict` from `collections` instead of `collections.abc`.

Fix issue https://github.com/noirbizarre/flask-restplus/issues/766.

Note that I haven't included the change to the CHANGELOG since this issue was created in the current version and there is already a change note about import compatibility with Python 3.7/3.8.