### PR TITLE
Removing Akamai License. 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,6 @@ BSD 3-Clause License
 
 Original work Copyright (c) 2013 Twilio, Inc
 Modified work Copyright (c) 2014 Axel Haustant
-Addition contributions Copyright (c) 2019 Akamai Technologies
 
 All rights reserved.
 


### PR DESCRIPTION
I, John Chittum, was the sole contributor from Akamai Technologies. However, my work on this project has been essentially administrative. I have not submitted any code changes to this codebase. My work relationship with Akamai Technologies ends on January 17th 2020. As such, Akamai being on the general license is unneeded. If other Akamai employess wish to contributor to this defunct codeline, please use a per commit style marking, stating copyright of the change is owned by Akamai Technologies.