### PR TITLE
added namespace example

### DIFF
--- a/doc/scaling.rst
+++ b/doc/scaling.rst
@@ -214,6 +214,20 @@ Given the previous layout, we can migrate it to the following directory structur
         ├── ...
         └── namespaceX.py
 
+Each `apis/namespaceX` wmodule will have the following pattern:
+
+.. code-block:: python
+
+    from flask_restplus import Namespace
+
+    api = Namespace('mynamespace', 'Namespace Description' )
+
+    @api.route("/")
+    class Myclass(Resource):
+        def get(self):
+            return {}
+
+
 Each `apivX` module will have the following pattern:
 
 .. code-block:: python


### PR DESCRIPTION
The documentation currently does not define an example of a modularized restapi due to the overloading of variables in previous examples (ie api = Api(..) vs api = Namespace) this has caused some confusion (and took myself an embarrassing amount of time to finally find the nugget in https://github.com/noirbizarre/flask-restplus/blob/master/examples/zoo/cat.py which finally got everything working).

This PR aims to address the confusion encountered in #468 

However, it might be worthwhile to clean up variables names so we are:
`from .apis.namespace1 import namespace as ns1` instead of `from .apis.namespace1 import api as ns1`

I am not sure of the intention of the variable names, and perhaps there is some logic that escapes me, so I opted not to clean that up in this PR instead of choosing instead to provide a complete example that works.