### PR TITLE
Documentation suggestions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -3,8 +3,8 @@ Contributing
 
 flask-restplus is open-source and very open to contributions. 
 
-If you're part of a corporation with an NDA, and you may require updating the license. 
-See Updating Copyright below
+If you're part of a corporation with an NDA, you may require updating the license. 
+See :ref:`Updating Copyright` below
 
 Submitting issues
 -----------------
@@ -106,6 +106,8 @@ For local development, you may wish to run a local server. running the following
 NOTE: You'll need `NPM <https://docs.npmjs.com/getting-started/>`_ installed to do this. 
 If you're new to NPM, also check out `nvm <https://github.com/creationix/nvm/blob/master/README.md>`_
 
+
+.. _Updating Copyright:
 
 Updating Copyright
 ------------------

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -74,7 +74,7 @@ class Api(object):
     :param str contact: A contact email for the API (used in Swagger documentation)
     :param str license: The license associated to the API (used in Swagger documentation)
     :param str license_url: The license page URL (used in Swagger documentation)
-    :param str endpoint: The API base endpoint (default to 'api).
+    :param str endpoint: The API base endpoint (default to 'api').
     :param str default: The default namespace base name (default to 'default')
     :param str default_label: The default namespace label (used in Swagger documentation)
     :param str default_mediatype: The default media type to return


### PR DESCRIPTION
As I was reading part of the documentation, I found a missing apostrophe in the documentation of the `Api` class.

In addition, I'm suggesting adding a jump link in the contributing document and smoothing out a sentence.